### PR TITLE
bunq transaction wait until fund has enough topped amount

### DIFF
--- a/app/Http/Controllers/Api/Platform/OrganizationsController.php
+++ b/app/Http/Controllers/Api/Platform/OrganizationsController.php
@@ -24,7 +24,7 @@ class OrganizationsController extends Controller
         return OrganizationResource::collection(
             Organization::queryByIdentityPermissions(
                 $identityAddress
-            )->orWhere('identity_address', $identityAddress)->get()
+            )->get()
         );
     }
 

--- a/app/Models/Fund.php
+++ b/app/Models/Fund.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
  * @property float $budget_total
  * @property float $budget_validated
  * @property float $budget_used
+ * @property float $budget_left
  * @property Media $logo
  * @property FundConfig $fund_config
  * @property Collection $metas
@@ -146,6 +147,13 @@ class Fund extends Model
     /**
      * @return float
      */
+    public function getBudgetValidatedAttribute() {
+        return 0;
+    }
+
+    /**
+     * @return float
+     */
     public function getBudgetTotalAttribute() {
         return round($this->top_ups()->where([
             'state' => 'confirmed'
@@ -155,15 +163,15 @@ class Fund extends Model
     /**
      * @return float
      */
-    public function getBudgetValidatedAttribute() {
-        return 0;
+    public function getBudgetUsedAttribute() {
+        return round($this->voucher_transactions->sum('amount'), 2);
     }
 
     /**
      * @return float
      */
-    public function getBudgetUsedAttribute() {
-        return round($this->voucher_transactions->sum('amount'), 2);
+    public function getBudgetLeftAttribute() {
+        return round($this->budget_total - $this->budget_used, 2);
     }
 
     /**

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -250,6 +250,6 @@ class Organization extends Model
                     })->get();
                 });
             });
-        });
+        })->orWhere('identity_address', $identityAddress);
     }
 }

--- a/app/Services/BunqService/BunqService.php
+++ b/app/Services/BunqService/BunqService.php
@@ -344,12 +344,20 @@ class BunqService
 
         /** @var VoucherTransaction $transaction */
         foreach($transactions as $transaction) {
+            $voucher = $transaction->voucher;
+
+            if ($voucher->fund->budget_left < $transaction->amount) {
+                $transaction->forceFill([
+                    'last_attempt_at'   => Carbon::now(),
+                ])->save();
+
+                continue;
+            }
+
             $transaction->forceFill([
                 'attempts'          => ++$transaction->attempts,
                 'last_attempt_at'   => Carbon::now(),
             ])->save();
-
-            $voucher = $transaction->voucher;
 
             try {
                 $bunq = $voucher->fund->getBunq();


### PR DESCRIPTION
- Bunq transaction wait until fund has enough topped amount
- Organization owner wasn't able to scan vouchers without being added as employee with scan vouchers permission