### PR TITLE
Fixed providers transactions not being counted properly

### DIFF
--- a/app/Http/Controllers/Api/Platform/Organizations/FundsController.php
+++ b/app/Http/Controllers/Api/Platform/Organizations/FundsController.php
@@ -285,7 +285,7 @@ class FundsController extends Controller
             )->whereBetween('created_at', [
                 $startDate, $endDate
             ])->count(),
-            'providers' => $providers->distinct()->groupBy('organization_id')->count()
+            'providers' => $providers->count(DB::raw('DISTICT organization_id'))
         ];
     }
 


### PR DESCRIPTION
Current situation: 
Query is perfomed like _SELECT DISTINCT COUNT(*) FROM voucher_transactions GROUP BY organization_id_

Should be: 
_SELECT COUNT(DISTINCT organization_id) FROM voucher_transactions;_