### PR TITLE
Feature voucher error handling

### DIFF
--- a/app/Exceptions/AuthorizationJsonException.php
+++ b/app/Exceptions/AuthorizationJsonException.php
@@ -1,0 +1,30 @@
+<?php
+
+
+namespace App\Exceptions;
+
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+
+class AuthorizationJsonException extends \Exception
+{
+    public function __toString()
+    {
+        return gettype($this->message);
+    }
+
+    public function render(Request $request)
+    {
+        return response()->json(array_merge(
+            json_decode($this->message, JSON_OBJECT_AS_ARRAY), config('app.debug') ? [
+                'file' => $this->getFile(),
+                'line' => $this->getLine(),
+                'trace' => collect($this->getTrace())->map(function ($trace) {
+                    return Arr::except($trace, ['args']);
+                })->all(),
+            ]: []
+        ), $this->getCode());
+    }
+
+}

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,10 +4,6 @@ namespace App\Exceptions;
 
 use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
-use Illuminate\Http\Exceptions\HttpResponseException;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 
 class Handler extends ExceptionHandler
 {
@@ -54,34 +50,5 @@ class Handler extends ExceptionHandler
     public function render($request, Exception $exception)
     {
         return parent::render($request, $exception);
-    }
-
-    /**
-     * Convert the given exception to an array.
-     *
-     * @param  \Exception  $e
-     * @return array
-     */
-    protected function convertExceptionToArray(Exception $e)
-    {
-        if ($e->getMessage() instanceof Collection) {
-            $message = collect($e->getMessage())->toArray();
-
-            $data = config('app.debug') ? $message :
-                $this->isHttpException($e) ? $message : [
-                'message' => 'Server Error'
-            ];
-
-            return array_merge(config('app.debug') ? [
-                'exception' => get_class($e),
-                'file' => $e->getFile(),
-                'line' => $e->getLine(),
-                'trace' => collect($e->getTrace())->map(function ($trace) {
-                    return Arr::except($trace, ['args']);
-                })->all(),
-            ] : [], $data);
-        }
-
-        return parent::convertExceptionToArray($e);
     }
 }

--- a/app/Models/Fund.php
+++ b/app/Models/Fund.php
@@ -41,6 +41,8 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
  * @property Collection|Validator[] $validators
  * @property Collection|Organization[] $provider_organizations
  * @property Collection|Organization[] $provider_organizations_approved
+ * @property Collection|Organization[] $provider_organizations_declined
+ * @property Collection|Organization[] $provider_organizations_pending
  * @property Carbon $start_date
  * @property Carbon $end_date
  * @property Carbon $created_at
@@ -231,6 +233,26 @@ class Fund extends Model
             Organization::class,
             'fund_providers'
         )->where('fund_providers.state', 'approved');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function provider_organizations_declined() {
+        return $this->belongsToMany(
+            Organization::class,
+            'fund_providers'
+        )->where('fund_providers.state', 'declined');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function provider_organizations_pending() {
+        return $this->belongsToMany(
+            Organization::class,
+            'fund_providers'
+        )->where('fund_providers.state', 'pending');
     }
 
     /**

--- a/app/Policies/VoucherPolicy.php
+++ b/app/Policies/VoucherPolicy.php
@@ -2,10 +2,10 @@
 
 namespace App\Policies;
 
+use App\Exceptions\AuthorizationJsonException;
 use App\Models\Fund;
 use App\Models\Organization;
 use App\Models\Voucher;
-use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class VoucherPolicy
@@ -136,40 +136,60 @@ class VoucherPolicy
      * @param string $identity_address
      * @param Voucher $voucher
      * @return bool
-     *
-     * @throws \Illuminate\Auth\Access\AuthorizationException
+     * @throws AuthorizationJsonException
      */
     public function useAsProvider(
         string $identity_address,
         Voucher $voucher
     ) {
+        $fund = $voucher->fund;
+        $id = 'fund_providers.id';
+
         if ($voucher->expire_at->isPast()) {
-            throw new AuthorizationException(trans(
-                'validation.voucher.expired'
-            ));
+            $this->deny('voucher_expired');
         }
 
         if ($voucher->fund->state != Fund::STATE_ACTIVE) {
-            throw new AuthorizationException(trans(
-                'validation.voucher.fund_not_active'
-            ));
+            $this->deny('fund_not_active');
         }
 
-        if ($voucher->type == 'regular') {
-            $organizations = $voucher->fund->provider_organizations_approved;
-            $identityOrganizations = Organization::queryByIdentityPermissions(
-                $identity_address, 'scan_vouchers'
-            )->pluck('id');
+        $providersApproved = $fund->provider_organizations_approved()
+            ->pluck($id);
+        $providersDeclined = $fund->provider_organizations_declined()
+            ->pluck($id);
+        $providersPending = $fund->provider_organizations_pending()
+            ->pluck($id);
+        $providersApplied = $fund->provider_organizations()
+            ->pluck($id);
 
-            return $identityOrganizations->intersect(
-                $organizations->pluck('id')
-                )->count() > 0;
+        $providers = Organization::queryByIdentityPermissions(
+            $identity_address, 'scan_vouchers'
+        )->pluck('id');
+
+        // None of identity organizations applied to the fund
+        if ($providers->intersect($providersApplied)->count() == 0) {
+            $this->deny('provider_not_applied');
+        }
+
+        // No approved identity organizations but have pending
+        if ($providers->intersect($providersApproved)->count() == 0 &&
+            $providers->intersect($providersPending)->count() > 0 ) {
+            $this->deny('provider_pending');
+        }
+
+        // No approved identity organizations but have declined
+        if ($providers->intersect($providersApproved)->count() == 0 &&
+            $providers->intersect($providersDeclined)->count() > 0 ) {
+            $this->deny('provider_declined');
+        }
+
+        // No approved identity organizations but hav pending
+        if ($voucher->type == 'regular') {
+            return $providers->intersect($providersApproved)->count() > 0;
         } else if ($voucher->type == 'product') {
             // Product vouchers can have no more than 1 transaction
             if ($voucher->transactions->count() > 0) {
-                throw new AuthorizationException(trans(
-                    'validation.voucher.product_voucher_used'
-                ));
+                $this->deny('product_voucher_used');
             }
 
             // The identity should be allowed to scan voucher for
@@ -194,5 +214,18 @@ class VoucherPolicy
         return $this->show($identity_address, $voucher) &&
             $voucher->parent_id != null &&
             $voucher->transactions->count() == 0;
+    }
+
+    /**
+     * @param string $error
+     * @throws AuthorizationJsonException
+     */
+    protected function deny(string $error)
+    {
+        $message = trans("validation.voucher.{$error}");
+
+        throw new AuthorizationJsonException(json_encode(
+            compact('error', 'message')
+        ), 403);
     }
 }

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -139,6 +139,7 @@ return [
         'provider_pending' => 'You can not scan this voucher! Your application for this fund is still pending.',
         'provider_denied' => 'You can not scan this voucher! Your application for this fund is denied.',
         'fund_not_active' => 'Your can not scan this voucher! The fund is not active (anymore).',
+        'not_enough_funds' => 'Not enough credit on voucher.',
     ],
 
 ];

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -132,5 +132,13 @@ return [
         'primary_email' => 'e-mail',
         'records.primary_email' => 'e-mail',
     ],
+    'voucher' => [
+        'expired' => 'This voucher is expired',
+        'product_voucher_used' => 'This product voucher is already used.',
+        'provider_not_applied' => 'You can not scan this voucher! You are not applied for this fund.',
+        'provider_pending' => 'You can not scan this voucher! Your application for this fund is still pending.',
+        'provider_denied' => 'You can not scan this voucher! Your application for this fund is denied.',
+        'fund_not_active' => 'Your can not scan this voucher! The fund is not active (anymore).',
+    ],
 
 ];

--- a/resources/lang/nl/validation.php
+++ b/resources/lang/nl/validation.php
@@ -130,6 +130,14 @@ return [
     'validation.prevalidation_missing_primary_key' => 'Het sleutelveld ontbreekt in het bestand.',	
     'iban' => 'Het IBAN-nummer is verplicht en moet geldig zijn.',
     'kvk' => 'Het KVK-nummer is verplicht en moet geldig zijn.',
+    'voucher' => [
+        'expired' => 'De voucher is verlopen.',
+        'product_voucher_used' => 'De voucher voor deze aanbieding is al gebruikt!',
+        'provider_not_applied' => 'U mag deze voucher niet scannen! Dit profiels organisatie is nog niet aangemeld bij het fonds van deze voucher.',
+        'provider_pending' => 'U mag deze voucher niet scannen! Status voor aanmelding van het fonds van deze voucher is wachtend.',
+        'provider_denied' => 'U mag deze voucher niet scannen! Uw organisatie is geweigerd om deel te nemen aan het fonds. Zoek contact op met sponsor voor een reden.',
+        'fund_not_active' => 'U mag deze voucher nog niet scannen! Het fonds is niet actief.',
+    ],
     'attributes' => [
         'pin_code' => 'pincode',
         'records' => 'Records',

--- a/resources/lang/nl/validation.php
+++ b/resources/lang/nl/validation.php
@@ -137,6 +137,7 @@ return [
         'provider_pending' => 'U mag deze voucher niet scannen! Status voor aanmelding van het fonds van deze voucher is wachtend.',
         'provider_denied' => 'U mag deze voucher niet scannen! Uw organisatie is geweigerd om deel te nemen aan het fonds. Zoek contact op met sponsor voor een reden.',
         'fund_not_active' => 'U mag deze voucher nog niet scannen! Het fonds is niet actief.',
+        'not_enough_funds' => 'Onvoldoende tegoed op de voucher.',
     ],
     'attributes' => [
         'pin_code' => 'pincode',


### PR DESCRIPTION
Now the `403` response will provide a json with 2 attributes 
```json
{
    "key": "string error code to be used by the app", 
    "message": "a string description to be shown to provider"
}
```

The messages may be edited in translation files [validation.voucher.@key@]

List keys:
Add error when voucher is expired
    - expired

Add error when product voucher is used.
    - product_voucher_used
    
Add error when provider isn't applied for fund (does not exist in fund_providers)
    - provider_not_applied

Add error when provider is pending for fund(not approved yet) (fund_providers state pending)
    - provider_pending 

Add error when provider is denied for fund (fund_providers state denied)
    - provider_denied 

The fund is not active 
    - fund_not_active

Product voucher already used
    - product_voucher_used
