### PR TITLE
Disabled product voucher assign mail

### DIFF
--- a/app/Services/Forus/Notification/NotificationService.php
+++ b/app/Services/Forus/Notification/NotificationService.php
@@ -435,6 +435,10 @@ class NotificationService
         string $type,
         $data
     ): bool {
+        // todo remove in next release
+        if($type == "product"){
+            return false;
+        }
         $mailable = new AssignedVoucherMail($emailFrom, $type, $data);
         return $mailable ? $this->sendMail($email, $mailable) : false;
     }


### PR DESCRIPTION
Sponsor wants to create QR-codes before start date of fund. Does not want to inform users that QR-code has been assigned. Next release we should enable it again. 