### PR TITLE
lorem db seeder: make providers, validators and product names longer

### DIFF
--- a/database/seeders/LoremDbSeeder.php
+++ b/database/seeders/LoremDbSeeder.php
@@ -30,7 +30,8 @@ use App\Models\VoucherTransaction;
 use App\Scopes\Builders\FundQuery;
 use App\Scopes\Builders\ProductQuery;
 use Carbon\Carbon;
-use Faker\Provider\Payment;
+use Faker\Factory;
+use Faker\Generator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Seeder;
@@ -126,6 +127,8 @@ class LoremDbSeeder extends Seeder
         'Nijmegen', 'Zuidhorn',
     ];
 
+    private Generator $faker;
+
     /**
      * LoremDbSeeder constructor.
      */
@@ -142,6 +145,8 @@ class LoremDbSeeder extends Seeder
         $this->primaryEmail = config('forus.seeders.lorem_db_seeder.default_email');
         $this->fundRequestEmailPattern = config('forus.seeders.lorem_db_seeder.fund_request_email_pattern');
         $this->vouchersPerFund = config('forus.seeders.lorem_db_seeder.vouchers_per_fund_count');
+
+        $this->faker = Factory::create(Config::get('app.locale'));
     }
 
     /**
@@ -469,7 +474,7 @@ class LoremDbSeeder extends Seeder
 
         while ($count-- > 0) {
             $out[] = $this->makeOrganization(
-                sprintf('%s #%s', $prefix, $nth++),
+                sprintf('%s #%s: %s', $prefix, $nth++, $this->makeRandomName(20, 40)),
                 $identity_address,
                 $fields,
                 $offices_count
@@ -495,7 +500,7 @@ class LoremDbSeeder extends Seeder
     ): Organization {
         $organization = Organization::create(array_only(array_merge([
             'kvk' => '69599068',
-            'iban' => $this->config('default_organization_iban') ?: Payment::iban('NL'),
+            'iban' => $this->config('default_organization_iban') ?: $this->faker->iban('NL'),
             'phone' => '123456789',
             'email' => $this->primaryEmail,
             'bsn_enabled' => true,
@@ -922,7 +927,7 @@ class LoremDbSeeder extends Seeder
         array $fields = []
     ): Product {
         do {
-            $name = 'Product #' . random_int(100000, 999999);
+            $name = '#' . random_int(100000, 999999) . " " . $this->makeRandomName();
         } while(Product::query()->where('name', $name)->count() > 0);
 
         $price = random_int(1, 20);
@@ -961,6 +966,21 @@ class LoremDbSeeder extends Seeder
         return $product;
     }
 
+    /**
+     * @param int $minLength
+     * @param int $maxLength
+     * @return string
+     * @throws \Exception
+     */
+    protected function makeRandomName(int $minLength = 75, int $maxLength = 150): string
+    {
+        return $this->faker->text(random_int(10, random_int(0, 3) >= 3 ? $maxLength : $minLength));
+    }
+
+    /**
+     * @param $fundName
+     * @return bool
+     */
     private function isUsingAutoValidation($fundName): bool
     {
         return in_array($fundName, $this->fundsWithAutoValidation, true);


### PR DESCRIPTION
Example: 
<img width="981" alt="image" src="https://user-images.githubusercontent.com/25606248/207821406-4644c580-8a7f-4487-a358-407bd3ab49f3.png">

Should help detect css issues for long names faster on the local environment.