### PR TITLE
Add deactivation sms codes for 2fa if created new one

### DIFF
--- a/app/Http/Requests/Api/Identity/Identity2FA/BaseIdentity2FARequest.php
+++ b/app/Http/Requests/Api/Identity/Identity2FA/BaseIdentity2FARequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\Api\Identity\Identity2FA;
 
 use App\Http\Requests\BaseFormRequest;
 use App\Models\Identity2FA;
+use App\Models\Identity2FACode;
 use Illuminate\Support\Facades\Config;
 use PragmaRX\Google2FA\Exceptions\IncompatibleWithGoogleAuthenticatorException;
 use PragmaRX\Google2FA\Exceptions\InvalidCharactersException;
@@ -60,6 +61,7 @@ abstract class BaseIdentity2FARequest extends BaseFormRequest
         $isValid = $identity2FA
             ->identity_2fa_codes()
             ->where('expire_at', '>', now())
+            ->where('status', Identity2FACode::STATUS_ACTIVE)
             ->where('code', $code)
             ->exists();
 

--- a/app/Http/Requests/Api/Identity/Identity2FA/BaseIdentity2FARequest.php
+++ b/app/Http/Requests/Api/Identity/Identity2FA/BaseIdentity2FARequest.php
@@ -61,7 +61,7 @@ abstract class BaseIdentity2FARequest extends BaseFormRequest
         $isValid = $identity2FA
             ->identity_2fa_codes()
             ->where('expire_at', '>', now())
-            ->where('status', Identity2FACode::STATUS_ACTIVE)
+            ->where('state', Identity2FACode::STATE_ACTIVE)
             ->where('code', $code)
             ->exists();
 

--- a/app/Models/Identity2FA.php
+++ b/app/Models/Identity2FA.php
@@ -211,6 +211,10 @@ class Identity2FA extends Model
      */
     public function sendCode(): bool
     {
+        $this->identity_2fa_codes()->update([
+            'status' => Identity2FACode::STATUS_DEACTIVATED
+        ]);
+
         return resolve('forus.services.sms_notification')->sendSms(
             'Confirmation code: ' . $this->makePhoneCode()->code,
             $this->phone,

--- a/app/Models/Identity2FA.php
+++ b/app/Models/Identity2FA.php
@@ -212,7 +212,7 @@ class Identity2FA extends Model
     public function sendCode(): bool
     {
         $this->identity_2fa_codes()->update([
-            'status' => Identity2FACode::STATUS_DEACTIVATED
+            'state' => Identity2FACode::STATE_DEACTIVATED
         ]);
 
         return resolve('forus.services.sms_notification')->sendSms(

--- a/app/Models/Identity2FACode.php
+++ b/app/Models/Identity2FACode.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property int $id
  * @property string $code
  * @property string $identity_2fa_uuid
- * @property string $status
+ * @property string $state
  * @property \Illuminate\Support\Carbon|null $expire_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
  * @property \Illuminate\Support\Carbon|null $created_at
@@ -28,7 +28,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode whereExpireAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode whereId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode whereIdentity2faUuid($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode whereStatus($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode whereState($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode whereUpdatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode withTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode withoutTrashed()
@@ -38,8 +38,8 @@ class Identity2FACode extends Model
 {
     use SoftDeletes;
 
-    public const STATUS_ACTIVE = 'active';
-    public const STATUS_DEACTIVATED = 'deactivated';
+    public const STATE_ACTIVE = 'active';
+    public const STATE_DEACTIVATED = 'deactivated';
 
     protected $table = 'identity_2fa_codes';
 
@@ -47,7 +47,7 @@ class Identity2FACode extends Model
      * @var string[]
      */
     protected $fillable = [
-        'code', 'expire_at', 'identity_2fa_uuid', 'status',
+        'code', 'expire_at', 'identity_2fa_uuid', 'state',
     ];
 
     /**

--- a/app/Models/Identity2FACode.php
+++ b/app/Models/Identity2FACode.php
@@ -11,25 +11,35 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  *
  * @property int $id
  * @property string $code
- * @property \Illuminate\Support\Carbon $identity_2fa_uuid
- * @property string|null $expire_at
+ * @property string $identity_2fa_uuid
+ * @property string $status
+ * @property \Illuminate\Support\Carbon|null $expire_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property-read \App\Models\Identity2FA|null $identity_2fa
  * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode onlyTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode query()
  * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode whereCode($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode whereDeletedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode whereExpireAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode whereId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode whereIdentity2faUuid($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode whereStatus($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode withTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder|Identity2FACode withoutTrashed()
  * @mixin \Eloquent
  */
 class Identity2FACode extends Model
 {
     use SoftDeletes;
+
+    public const STATUS_ACTIVE = 'active';
+    public const STATUS_DEACTIVATED = 'deactivated';
 
     protected $table = 'identity_2fa_codes';
 
@@ -37,7 +47,7 @@ class Identity2FACode extends Model
      * @var string[]
      */
     protected $fillable = [
-        'code', 'expire_at', 'identity_2fa_uuid',
+        'code', 'expire_at', 'identity_2fa_uuid', 'status',
     ];
 
     /**

--- a/database/migrations/2023_07_20_215618_add_state_to_identity_2fa_code.php
+++ b/database/migrations/2023_07_20_215618_add_state_to_identity_2fa_code.php
@@ -14,7 +14,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('identity_2fa_codes', function (Blueprint $table) {
-            $table->string('status', 20)->default('active')->after('identity_2fa_uuid');
+            $table->string('state', 20)->default('active')->after('identity_2fa_uuid');
         });
     }
 
@@ -26,7 +26,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('identity_2fa_codes', function (Blueprint $table) {
-            $table->dropColumn('status');
+            $table->dropColumn('state');
         });
     }
 };

--- a/database/migrations/2023_07_20_215618_add_status_to_identity_2fa_code.php
+++ b/database/migrations/2023_07_20_215618_add_status_to_identity_2fa_code.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('identity_2fa_codes', function (Blueprint $table) {
+            $table->string('status', 20)->default('active')->after('identity_2fa_uuid');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('identity_2fa_codes', function (Blueprint $table) {
+            $table->dropColumn('status');
+        });
+    }
+};

--- a/tests/Feature/Identity2FATest.php
+++ b/tests/Feature/Identity2FATest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Helpers\Arr;
 use App\Models\Identity;
 use App\Models\Identity2FA;
+use App\Models\Identity2FACode;
 use App\Models\IdentityProxy;
 use App\Models\Organization;
 use App\Models\Role;
@@ -246,9 +247,20 @@ class Identity2FATest extends TestCase
         // assert 2fa confirmation/activation works
         /** @var TestResponse $response */
         $response = $this->assertNoException(function () use ($identityProxy, $identity2FA) {
-            $code = $identity2FA->isTypeAuthenticator() ?
-                $identity2FA->makeAuthenticatorCode() :
-                $identity2FA->makePhoneCode()->code;
+            if ($identity2FA->isTypeAuthenticator()) {
+                $code = $identity2FA->makeAuthenticatorCode();
+            } else {
+                $deactivatedCode = $this->sendCodeToPhone($identity2FA);
+                sleep(1);
+                $code = $this->sendCodeToPhone($identity2FA);
+
+                $response = $this->postJson("/api/v1/identity/2fa/$identity2FA->uuid/activate", [
+                    'key' => $identity2FA->auth_2fa_provider->key,
+                    'code' => "$deactivatedCode",
+                ], $this->makeApiHeaders($identityProxy));
+
+                $response->assertJsonValidationErrorFor('code');
+            }
 
             return $this->postJson("/api/v1/identity/2fa/$identity2FA->uuid/activate", [
                 'key' => $identity2FA->auth_2fa_provider->key,
@@ -293,9 +305,19 @@ class Identity2FATest extends TestCase
         $this->assertNotNull($identity2FA);
 
         $response = $this->assertNoException(function () use ($identityProxy, $identity2FA) {
-            $code = $identity2FA->isTypeAuthenticator() ?
-                $identity2FA->makeAuthenticatorCode() :
-                $identity2FA->makePhoneCode()->code;
+            if ($identity2FA->isTypeAuthenticator()) {
+                $code = $identity2FA->makeAuthenticatorCode();
+            } else {
+                $deactivatedCode = $this->sendCodeToPhone($identity2FA);
+                sleep(1);
+                $code = $this->sendCodeToPhone($identity2FA);
+
+                $response = $this->postJson("/api/v1/identity/2fa/$identity2FA->uuid/authenticate", [
+                    'code' => "$deactivatedCode",
+                ], $this->makeApiHeaders($identityProxy));
+
+                $response->assertJsonValidationErrorFor('code');
+            }
 
             return $this->postJson("/api/v1/identity/2fa/$identity2FA->uuid/authenticate", [
                 'code' => "$code",
@@ -303,5 +325,23 @@ class Identity2FATest extends TestCase
         });
 
         $response->assertStatus(200);
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    protected function sendCodeToPhone(Identity2FA $identity2FA): string
+    {
+        $now = now();
+        $identity2FA->sendCode();
+
+        /** @var Identity2FACode $code */
+        $code = $identity2FA->identity_2fa_codes()
+            ->where('created_at', '>=', $now)
+            ->first();
+
+        $this->assertNotNull($code);
+
+        return $code->code;
     }
 }

--- a/tests/Feature/Identity2FATest.php
+++ b/tests/Feature/Identity2FATest.php
@@ -252,14 +252,9 @@ class Identity2FATest extends TestCase
             } else {
                 $deactivatedCode = $this->sendCodeToPhone($identity2FA);
                 sleep(1);
+
                 $code = $this->sendCodeToPhone($identity2FA);
-
-                $response = $this->postJson("/api/v1/identity/2fa/$identity2FA->uuid/activate", [
-                    'key' => $identity2FA->auth_2fa_provider->key,
-                    'code' => "$deactivatedCode",
-                ], $this->makeApiHeaders($identityProxy));
-
-                $response->assertJsonValidationErrorFor('code');
+                $this->assertInvalidCode($identity2FA, $deactivatedCode, $this->makeApiHeaders($identityProxy));
             }
 
             return $this->postJson("/api/v1/identity/2fa/$identity2FA->uuid/activate", [
@@ -310,13 +305,9 @@ class Identity2FATest extends TestCase
             } else {
                 $deactivatedCode = $this->sendCodeToPhone($identity2FA);
                 sleep(1);
+
                 $code = $this->sendCodeToPhone($identity2FA);
-
-                $response = $this->postJson("/api/v1/identity/2fa/$identity2FA->uuid/authenticate", [
-                    'code' => "$deactivatedCode",
-                ], $this->makeApiHeaders($identityProxy));
-
-                $response->assertJsonValidationErrorFor('code');
+                $this->assertInvalidCode($identity2FA, $deactivatedCode, $this->makeApiHeaders($identityProxy));
             }
 
             return $this->postJson("/api/v1/identity/2fa/$identity2FA->uuid/authenticate", [
@@ -343,5 +334,24 @@ class Identity2FATest extends TestCase
         $this->assertNotNull($code);
 
         return $code->code;
+    }
+
+    /**
+     * @param Identity2FA $identity2FA
+     * @param string $deactivatedCode
+     * @param array $apiHeaders
+     * @return void
+     */
+    protected function assertInvalidCode(
+        Identity2FA $identity2FA,
+        string $deactivatedCode,
+        array $apiHeaders
+    ): void {
+        $response = $this->postJson("/api/v1/identity/2fa/$identity2FA->uuid/activate", [
+            'key' => $identity2FA->auth_2fa_provider->key,
+            'code' => "$deactivatedCode",
+        ], $apiHeaders);
+
+        $response->assertJsonValidationErrorFor('code');
     }
 }


### PR DESCRIPTION
## Developers checklist
- [x] **Autotests are passed locally**
- [x] **Migration rollback works** - if there is migration, check rollback
- [x] **Autotests are added**:
   - sms code invalid if new one created
