### PR TITLE
add country prefixes for 2fa phone authentication

### DIFF
--- a/app/Http/Requests/Api/Identity/Identity2FA/StoreIdentity2FARequest.php
+++ b/app/Http/Requests/Api/Identity/Identity2FA/StoreIdentity2FARequest.php
@@ -42,9 +42,8 @@ class StoreIdentity2FARequest extends BaseIdentity2FARequest
         ], $type === Auth2FAProvider::TYPE_PHONE ? [
             'phone' => [
                 'required',
-                'string',
-                'max:15',
-                'starts_with:+',
+                'numeric',
+                'digits_between:8,15',
                 Rule::unique('identity_2fa', 'phone')->where('state', Identity2FA::STATE_ACTIVE),
             ]
         ] : []);

--- a/app/Http/Requests/Api/Identity/Identity2FA/StoreIdentity2FARequest.php
+++ b/app/Http/Requests/Api/Identity/Identity2FA/StoreIdentity2FARequest.php
@@ -43,8 +43,8 @@ class StoreIdentity2FARequest extends BaseIdentity2FARequest
             'phone' => [
                 'required',
                 'string',
-                'size:12',
-                'starts_with:+31',
+                'max:15',
+                'starts_with:+',
                 Rule::unique('identity_2fa', 'phone')->where('state', Identity2FA::STATE_ACTIVE),
             ]
         ] : []);

--- a/tests/Feature/Identity2FATest.php
+++ b/tests/Feature/Identity2FATest.php
@@ -203,7 +203,7 @@ class Identity2FATest extends TestCase
         $response = $this->postJson('/api/v1/identity/2fa', match ($type) {
             'phone' => [
                 'type' => 'phone',
-                'phone' => '+31123456789',
+                'phone' => '31123456789',
             ],
             'authenticator' => [
                 'type' => 'authenticator',


### PR DESCRIPTION
## Changes description
<!--- Describe shortly changes here if:
       - your solution differs from issue desrciption
       - there are advices from development side for QA or other stakeholders
-->

## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
