### PR TITLE
separate logs and remove auth and throttle logs

### DIFF
--- a/app/Exceptions/AuthorizationJsonException.php
+++ b/app/Exceptions/AuthorizationJsonException.php
@@ -11,7 +11,7 @@ class AuthorizationJsonException extends \Exception
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return gettype($this->message);
     }
@@ -25,9 +25,7 @@ class AuthorizationJsonException extends \Exception
             json_decode($this->message, JSON_OBJECT_AS_ARRAY), config('app.debug', false) ? [
                 'file' => $this->getFile(),
                 'line' => $this->getLine(),
-                'trace' => collect($this->getTrace())->map(function ($trace) {
-                    return Arr::except($trace, ['args']);
-                })->all(),
+                'trace' => array_map(fn ($trace) => Arr::except($trace, ['args']), $this->getTrace()),
             ]: []
         ), $this->getCode());
     }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -13,7 +13,9 @@ class Handler extends ExceptionHandler
      *
      * @var array
      */
-    protected $dontReport = [];
+    protected $dontReport = [
+        AuthorizationJsonException::class,
+    ];
 
     /**
      * A list of the inputs that are never flashed for validation exceptions.

--- a/app/Services/BNGService/Exceptions/ApiException.php
+++ b/app/Services/BNGService/Exceptions/ApiException.php
@@ -4,7 +4,4 @@ namespace App\Services\BNGService\Exceptions;
 
 use Exception;
 
-class ApiException extends Exception
-{
-
-}
+class ApiException extends Exception {}

--- a/app/Services/DigIdService/Models/DigIdSession.php
+++ b/app/Services/DigIdService/Models/DigIdSession.php
@@ -230,7 +230,8 @@ class DigIdSession extends Model
      */
     private function setError($message, $errorCode): self
     {
-        Log::error(sprintf('Could not make digid auth request, got %s: %s', $errorCode, $message));
+        Log::channel('digid')->error("Could not make digid auth request: $errorCode - $message");
+
         $canceled = $errorCode == DigIdCgiRepo::DIGID_CANCELLED;
 
         return $this->updateModel([

--- a/app/Services/KvkApiService/KvkApi.php
+++ b/app/Services/KvkApiService/KvkApi.php
@@ -4,6 +4,7 @@ namespace App\Services\KvkApiService;
 
 use GuzzleHttp\Client;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Class KvkApi
@@ -58,9 +59,7 @@ class KvkApi
             $response = json_decode($this->makeApiCall($kvk_number, $detailed), false);
             return is_object($response) ? $response : null;
         } catch (\Throwable $e) {
-            if ($logger = logger()) {
-                $logger->error($e->getMessage());
-            }
+            Log::channel('kvk')->warning($e->getMessage());
         }
 
         return null;

--- a/config/logging.php
+++ b/config/logging.php
@@ -44,6 +44,30 @@ return [
             'level' => 'debug',
         ],
 
+        'kvk' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/kvk-service.log'),
+            'level' => 'debug',
+        ],
+
+        'bunq' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/bunq-service.log'),
+            'level' => 'debug',
+        ],
+
+        'bng' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/bng-service.log'),
+            'level' => 'debug',
+        ],
+
+        'digid' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/digid-service.log'),
+            'level' => 'debug',
+        ],
+
         'daily' => [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),


### PR DESCRIPTION
## Changes description
- auth and throttle logs removed
- bng, bunq, kvk and digid related logs moved to separate files

## Developers checklist
- [x] **Autotests are passed locally**
- [x] **Migration rollback works** - if there is migration, check rollback

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
