### PR TITLE
add select_number type to record_types

### DIFF
--- a/app/Models/RecordType.php
+++ b/app/Models/RecordType.php
@@ -69,6 +69,7 @@ class RecordType extends BaseModel
     public const TYPE_STRING = 'string';
     public const TYPE_NUMBER = 'number';
     public const TYPE_SELECT = 'select';
+    public const TYPE_SELECT_NUMBER = 'select_number';
 
     public const TYPES = [
         self::TYPE_BOOL,
@@ -78,6 +79,7 @@ class RecordType extends BaseModel
         self::TYPE_STRING,
         self::TYPE_NUMBER,
         self::TYPE_SELECT,
+        self::TYPE_SELECT_NUMBER,
     ];
 
     /**
@@ -212,19 +214,17 @@ class RecordType extends BaseModel
      */
     public function getOperators(): array
     {
-        if (in_array($this->type, ['number', 'date'], true)) {
-            return ['<', '<=', '=', '>=', '>', '*'];
-        }
-
-        if (in_array($this->type, ['string', 'select', 'bool'], true)) {
-            return ['=', '*'];
-        }
-
-        if (in_array($this->type, ['iban', 'email'], true)) {
-            return ['*'];
-        }
-
-        return [];
+        return match ($this->type) {
+            self::TYPE_DATE,
+            self::TYPE_NUMBER => ['<', '<=', '=', '>=', '>', '*'],
+            self::TYPE_SELECT_NUMBER => ['<=', '=', '>=', '*'],
+            self::TYPE_BOOL,
+            self::TYPE_STRING,
+            self::TYPE_SELECT => ['=', '*'],
+            self::TYPE_IBAN,
+            self::TYPE_EMAIL => ['*'],
+            default => [],
+        };
     }
 
     /**

--- a/app/Rules/FundCriteria/FundCriteriaValueRule.php
+++ b/app/Rules/FundCriteria/FundCriteriaValueRule.php
@@ -43,7 +43,8 @@ class FundCriteriaValueRule extends BaseFundCriteriaRule
                 is_numeric($min) ? "|min:$min" : "",
                 is_numeric($max) ? "|max:$max" : "",
             ])),
-            $recordType::TYPE_SELECT => Validation::check($value, [
+            $recordType::TYPE_SELECT,
+            $recordType::TYPE_SELECT_NUMBER => Validation::check($value, [
                 'nullable',
                 Rule::in(Arr::pluck($recordType->getOptions(), 'value')),
             ]),

--- a/app/Rules/FundRequests/BaseFundRequestRule.php
+++ b/app/Rules/FundRequests/BaseFundRequestRule.php
@@ -14,6 +14,7 @@ use App\Rules\FundRequests\RecordTypes\RecordTypeDateRule;
 use App\Rules\FundRequests\RecordTypes\RecordTypeEmailRule;
 use App\Rules\FundRequests\RecordTypes\RecordTypeIbanRule;
 use App\Rules\FundRequests\RecordTypes\RecordTypeNumericRule;
+use App\Rules\FundRequests\RecordTypes\RecordTypeSelectNumberRule;
 use App\Rules\FundRequests\RecordTypes\RecordTypeSelectRule;
 use App\Rules\FundRequests\RecordTypes\RecordTypeStringRule;
 use Illuminate\Validation\Rule;
@@ -46,6 +47,7 @@ abstract class BaseFundRequestRule extends BaseRule
             $recordType::TYPE_STRING => Validation::check($value, new RecordTypeStringRule($criterion)),
             $recordType::TYPE_NUMBER => Validation::check($value, new RecordTypeNumericRule($criterion)),
             $recordType::TYPE_SELECT => Validation::check($value, new RecordTypeSelectRule($criterion)),
+            $recordType::TYPE_SELECT_NUMBER => Validation::check($value, new RecordTypeSelectNumberRule($criterion)),
             $recordType::TYPE_EMAIL => Validation::check($value, new RecordTypeEmailRule($criterion)),
             $recordType::TYPE_IBAN => Validation::check($value, new RecordTypeIbanRule($criterion)),
             $recordType::TYPE_BOOL => Validation::check($value, new RecordTypeBoolRule($criterion)),

--- a/app/Rules/FundRequests/RecordTypes/RecordTypeSelectNumberRule.php
+++ b/app/Rules/FundRequests/RecordTypes/RecordTypeSelectNumberRule.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Rules\FundRequests\RecordTypes;
+
+use Illuminate\Support\Arr;
+use Illuminate\Validation\Rule;
+
+class RecordTypeSelectNumberRule extends BaseRecordTypeRule
+{
+    /**
+     * @return array
+     */
+    public function rules(): array
+    {
+        return array_filter([
+            $this->isRequiredRule(),
+            'numeric',
+            Rule::in(Arr::pluck($this->criterion->record_type->getOptions(), 'value')),
+            match($this->criterion->operator) {
+                '=' => Rule::in([$this->criterion->value]),
+                '<=' => 'lte:' . intval($this->criterion->value),
+                '>=' => 'gte:' . intval($this->criterion->value),
+                '*' => Rule::in(Arr::pluck($this->criterion->record_type->getOptions(), 'value')),
+                default => Rule::in([]),
+            },
+        ]);
+    }
+}

--- a/database/migrations/2024_03_06_160409_add_select_number_type_to_record_types_table.php
+++ b/database/migrations/2024_03_06_160409_add_select_number_type_to_record_types_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('record_types', function (Blueprint $table) {
+            $recordTypes = ['string', 'select', 'select_number', 'number', 'iban', 'email', 'date', 'bool'];
+
+            Schema::table('record_types', function (Blueprint $table) {
+                $table->renameColumn('type', 'type_tmp');
+            });
+
+            Schema::table('record_types', function (Blueprint $table) use ($recordTypes) {
+                $table->enum('type', $recordTypes)->default('string')->after('key');
+            });
+
+            DB::table('record_types')->update([
+                'type' => DB::raw('`type_tmp`'),
+            ]);
+
+            Schema::table('record_types', function (Blueprint $table) {
+                $table->dropColumn('type_tmp');
+            });
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down() {}
+};

--- a/tests/Feature/FundCriteriaTest.php
+++ b/tests/Feature/FundCriteriaTest.php
@@ -314,6 +314,7 @@ class FundCriteriaTest extends TestCase
             $this->makeRequestCriterionValue($fund, "test_string_any", 'ipsum_lorem'),
             $this->makeRequestCriterionValue($fund, "test_number", 7),
             $this->makeRequestCriterionValue($fund, "test_select", 'foo'),
+            $this->makeRequestCriterionValue($fund, "test_select_number", 2),
         ], false);
 
         $response->assertSuccessful();
@@ -358,6 +359,7 @@ class FundCriteriaTest extends TestCase
             $this->makeRequestCriterionValue($fund, "test_string_any", 'ipsum_lorem'),
             $this->makeRequestCriterionValue($fund, "test_number", 7),
             $this->makeRequestCriterionValue($fund, "test_select", 'foo'),
+            $this->makeRequestCriterionValue($fund, "test_select_number", 2),
         ], [
             'uid' => token_generator()->generate(32),
         ]);
@@ -393,6 +395,7 @@ class FundCriteriaTest extends TestCase
             $this->makeRequestCriterionValue($fund, "test_string", 'ipsum_lorem'),
             $this->makeRequestCriterionValue($fund, "test_number", 5),
             $this->makeRequestCriterionValue($fund, "test_select", 'bar'),
+            $this->makeRequestCriterionValue($fund, "test_select_number", 1),
         ];
 
         $errors = array_map(fn ($index) => "records.$index.value", range(0, count($records) - 1));
@@ -469,6 +472,7 @@ class FundCriteriaTest extends TestCase
             $this->makeRequestCriterionValue($fund, "test_string_any", null),
             $this->makeRequestCriterionValue($fund, "test_number", null),
             $this->makeRequestCriterionValue($fund, "test_select", null),
+            $this->makeRequestCriterionValue($fund, "test_select_number", null),
         ];
 
         $response = $this->makeFundRequest($identity, $fund, $records, false);
@@ -520,6 +524,7 @@ class FundCriteriaTest extends TestCase
         $this->makeRecordType($fund->organization, RecordType::TYPE_STRING, "test_string_any");
         $this->makeRecordType($fund->organization, RecordType::TYPE_NUMBER, "test_number");
         $this->makeRecordType($fund->organization, RecordType::TYPE_SELECT, "test_select");
+        $this->makeRecordType($fund->organization, RecordType::TYPE_SELECT_NUMBER, "test_select_number");
 
         $response = $this->updateCriteriaRequest([
             $this->makeCriterion("test_bool", 'Ja', '='),
@@ -530,6 +535,7 @@ class FundCriteriaTest extends TestCase
             $this->makeCriterion("test_string_any", null, '*', 5, 20),
             $this->makeCriterion("test_number", '7', '>=', 5, 10),
             $this->makeCriterion("test_select", 'foo', '='),
+            $this->makeCriterion("test_select_number", 2, '>='),
         ], $fund);
 
         $fund->organization->forceFill([
@@ -566,6 +572,16 @@ class FundCriteriaTest extends TestCase
                  'name' => 'Bar',
              ]]);
          }
+
+        if ($type === $recordType::TYPE_SELECT_NUMBER) {
+            $recordType->record_type_options()->createMany([[
+                'value' => 1,
+                'name' => 'Foo',
+            ], [
+                'value' => 2,
+                'name' => 'Bar',
+            ]]);
+        }
 
          return $recordType;
     }
@@ -630,7 +646,8 @@ class FundCriteriaTest extends TestCase
                 $recordType::TYPE_BOOL => random_int(0, 1) ? 'Ja' : 'Nee',
                 $recordType::TYPE_IBAN => $this->faker->iban('NL'),
                 $recordType::TYPE_EMAIL => $this->faker->email(),
-                $recordType::TYPE_SELECT => !empty($options) ? array_first($options) : null,
+                $recordType::TYPE_SELECT,
+                $recordType::TYPE_SELECT_NUMBER => !empty($options) ? array_first($options) : null,
                 $recordType::TYPE_STRING => token_generator()->generate(10),
                 default => token_generator()->generate(5),
             };


### PR DESCRIPTION
## Changes description


## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
