### PR TITLE
Fix 50 mins running feature tests in CI

### DIFF
--- a/.github/workflows/unit_and_feature_tests.yml
+++ b/.github/workflows/unit_and_feature_tests.yml
@@ -1,12 +1,22 @@
 name: Run unit and feature tests
 
-on: [pull_request]
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: 'Enable debug mode'
+        required: false
+        default: 'true'
 
 jobs:
 
   build:
 
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: forus-backend
 
     steps:
       - name: Checkout forus-backend repo
@@ -15,41 +25,40 @@ jobs:
           path: forus-backend
 
       - name: Copy .env.docker.dusk file to .env
-        working-directory: forus-backend
         run: cp -n .env.docker.dusk .env
 
-      - name: Run docker-compose up
-        working-directory: forus-backend
+      - name: Run docker compose up
         run: docker compose --profile testing up -d
 
-      - name: Crutch - set correct ownership of files in docker
-        working-directory: forus-backend
+      - name: Set correct ownership of files in docker
         run: docker exec -u 0 forus-backend-app chown -R forus:forus /var/www/
 
       - name: Install dependencies
-        working-directory: forus-backend
         run: docker compose exec -T app bash -c "composer install"
 
-      - name: Create database structure with artisan
-        working-directory: forus-backend
+      - name: Create database structure
         run: docker compose exec -T app bash -c "composer dumpautoload && php artisan migrate"
 
       - name: Set app key
-        working-directory: forus-backend
         run: docker compose exec -T app bash -c "php artisan key:generate"
 
       - name: Run base seeders
-        working-directory: forus-backend
         run: docker compose exec -T app bash -c "php artisan db:seed"
 
       - name: Generate test data
-        working-directory: forus-backend
         run: docker compose exec -T app php artisan test-data:seed
 
-      - name: --- RUN UNIT TESTS ----
-        working-directory: forus-backend
-        run: docker compose exec -T app bash -c "./vendor/bin/phpunit --debug --testdox tests/Unit/."
+      - name: Set debug based on input
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ "${{ inputs.debug }}" == "true" ]; then
+            echo "DEBUG=--debug" >> $GITHUB_ENV
+          else
+            echo "DEBUG=" >> $GITHUB_ENV
+          fi
 
-      - name: --- RUN FEATURE TESTS ----
+      - name: --- RUN UNIT TESTS ---
+        run: docker compose exec -T app bash -c "./vendor/bin/phpunit $DEBUG_FLAG tests/Unit/."
+
+      - name: --- RUN FEATURE TESTS ---
         working-directory: forus-backend
-        run: docker compose exec -T app bash -c "./vendor/bin/phpunit --debug --testdox tests/Feature/."
+        run: docker compose exec -T app bash -c "./vendor/bin/phpunit $DEBUG_FLAG tests/Feature/."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   app:
     build:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,27 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-        <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="BCRYPT_ROUNDS" value="4"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
-        <env name="MAIL_MAILER" value="array"/>
-        <env name="QUEUE_DRIVER" value="sync"/>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="TELESCOPE_ENABLED" value="false"/>
-        <env name="TEST_DATA_CONFIG" value="default"/>
-        <env name="TWILIO_DEBUG" value="true"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.2/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+    <testsuite name="Feature">
+      <directory suffix="Test.php">./tests/Feature</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="BCRYPT_ROUNDS" value="4"/>
+    <env name="CACHE_DRIVER" value="array"/>
+    <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
+    <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+    <env name="MAIL_MAILER" value="array"/>
+    <env name="QUEUE_DRIVER" value="sync"/>
+    <env name="SESSION_DRIVER" value="array"/>
+    <env name="TELESCOPE_ENABLED" value="false"/>
+    <env name="TEST_DATA_CONFIG" value="default"/>
+    <env name="TWILIO_DEBUG" value="true"/>
+  </php>
 </phpunit>

--- a/tests/Feature/VoucherTransactionBatchTest.php
+++ b/tests/Feature/VoucherTransactionBatchTest.php
@@ -71,7 +71,7 @@ class VoucherTransactionBatchTest extends TestCase
 
         $transactions = [];
         $errors = [];
-        $rows = 3000;
+        $rows = 150;
 
         foreach (range(0, $rows) as $item) {
             $transactions[] = array_merge($this->getDefaultTransactionData(), [


### PR DESCRIPTION
## Changes description
<!--- Describe shortly changes here if:
       - your solution differs from issue desrciption
       - there are advices from development side for QA or other stakeholders
-->
There was a problem that tests executing for 50 mins
<img width="159" alt="Screenshot 2024-09-04 at 11 56 43" src="https://github.com/user-attachments/assets/7041f164-a0c1-4114-9f31-4308a6f588c5">

Reason of feature tests running for 50 mins was big amount of batches, which runs slowly in CI due to big output (6gb log)

- Decreased batch amount to 150
- Additionally fixed warning of docker compose for deprecated versioning in docker-compose file 
- Regenerated PHPUnit XML with phpunit --migrate-configuration    
- Some minor CI fixes

## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
