### PR TITLE
fix deprecated string interpolation

### DIFF
--- a/app/Services/Forus/Notification/Commands/NotificationsTokensImportCommand.php
+++ b/app/Services/Forus/Notification/Commands/NotificationsTokensImportCommand.php
@@ -74,6 +74,6 @@ class NotificationsTokensImportCommand extends Command
             }
         }
 
-        $this->line("${$countSuccess} rows imported, ${$countError} rows failed.");
+        $this->line("{${$countSuccess}} rows imported, {${$countError}} rows failed.");
     }
 }

--- a/app/Services/Forus/Notification/Commands/NotificationsTokensImportCommand.php
+++ b/app/Services/Forus/Notification/Commands/NotificationsTokensImportCommand.php
@@ -74,6 +74,6 @@ class NotificationsTokensImportCommand extends Command
             }
         }
 
-        $this->line("{${$countSuccess}} rows imported, {${$countError}} rows failed.");
+        $this->line("$countSuccess rows imported, $countError rows failed.");
     }
 }


### PR DESCRIPTION
## Changes description
<!--- Describe shortly changes here if:
       - your solution differs from issue desrciption
       - there are advices from development side for QA or other stakeholders
-->
Met deprecation warning in prod notification log
<img width="1590" alt="Screenshot 2024-09-11 at 10 36 48" src="https://github.com/user-attachments/assets/3bb0a619-d293-4f50-b1cc-b3cfde412642">

Fixed according to https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
