### PR TITLE
fix requesting funds without formula and updated tests

### DIFF
--- a/app/Http/Requests/Api/Platform/Funds/Requests/ApproveFundRequestsRequest.php
+++ b/app/Http/Requests/Api/Platform/Funds/Requests/ApproveFundRequestsRequest.php
@@ -79,7 +79,7 @@ class ApproveFundRequestsRequest extends BaseFormRequest
             $fund->fund_config->allow_preset_amounts_validator ? [
             $this->hasFormula($fund) ? 'nullable' : (
             $fund->organization->allow_payouts && $fund->fund_config->allow_custom_amounts_validator ?
-                'required_without:fund_amount_preset_id' :
+                'required_without:amount' :
                 'required'
             ),
             Rule::exists('fund_amount_presets', 'id')->where('fund_id', $fund->id),

--- a/app/Listeners/FundRequestSubscriber.php
+++ b/app/Listeners/FundRequestSubscriber.php
@@ -91,6 +91,7 @@ class FundRequestSubscriber
             IdentityFundRequestDisregardedNotification::send($eventLog);
         }
 
+
         if ($fundRequest->isApproved()) {
             /** @var Fund[] $funds */
             $funds = [];

--- a/app/Models/Fund.php
+++ b/app/Models/Fund.php
@@ -1250,24 +1250,25 @@ class Fund extends BaseModel
     ): ?Voucher {
         $presetModel = $amount instanceof FundAmountPreset ? $amount : null;
 
-        $voucher = null;
+        if ($this->fund_formulas->count() === 0 && $amount === null) {
+            return null;
+        }
+
         $amount = $presetModel ? $presetModel->amount : $amount;
         $amount = $amount === null ? $this->amountForIdentity($identity_address) : $amount;
 
-        if ($this->fund_formulas->count() > 0) {
-            $voucher = Voucher::create([
-                'identity_address' => $identity_address,
-                'amount' => $amount,
-                'expire_at' => $expire_at ?: $this->end_date,
-                'fund_id' => $this->id,
-                'returnable' => false,
-                'limit_multiplier' => $limit_multiplier ?: $this->multiplierForIdentity($identity_address),
-                'fund_amount_preset_id' => $presetModel?->id,
-                ...$voucherFields,
-            ]);
+        $voucher = Voucher::create([
+            'identity_address' => $identity_address,
+            'amount' => $amount,
+            'expire_at' => $expire_at ?: $this->end_date,
+            'fund_id' => $this->id,
+            'returnable' => false,
+            'limit_multiplier' => $limit_multiplier ?: $this->multiplierForIdentity($identity_address),
+            'fund_amount_preset_id' => $presetModel?->id,
+            ...$voucherFields,
+        ]);
 
-            VoucherCreated::dispatch($voucher);
-        }
+        VoucherCreated::dispatch($voucher);
 
         return $voucher;
     }

--- a/app/Traits/DoesTesting.php
+++ b/app/Traits/DoesTesting.php
@@ -68,14 +68,18 @@ trait DoesTesting
     }
 
     /**
-     * @param IdentityProxy|bool|null $authProxy
+     * @param IdentityProxy|Identity|bool $authProxy
      * @param array $headers
      * @return array
      */
-    protected function makeApiHeaders(IdentityProxy|bool $authProxy = false, array $headers = []): array
-    {
-        if ($authProxy === true) {
-            $authProxy = $this->makeIdentityProxy($this->makeIdentity());
+    protected function makeApiHeaders(
+        IdentityProxy|Identity|bool $authProxy = false,
+        array $headers = [],
+    ): array {
+        if ($authProxy instanceof Identity || $authProxy === true) {
+            $authProxy = $this->makeIdentityProxy(
+                $authProxy instanceof Identity ? $authProxy : $this->makeIdentity()
+            );
         }
 
         return array_merge([

--- a/tests/Feature/EmployeeTest.php
+++ b/tests/Feature/EmployeeTest.php
@@ -39,7 +39,7 @@ class EmployeeTest extends TestCase
     {
         $organization = Organization::first();
         $this->assertNotNull($organization);
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($organization->identity));
+        $headers = $this->makeApiHeaders($organization->identity);
         $employeeData = $this->makeEmployeeData();
 
         // make valid store employee request
@@ -63,7 +63,7 @@ class EmployeeTest extends TestCase
     {
         $organization = Organization::first();
         $this->assertNotNull($organization);
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($organization->identity));
+        $headers = $this->makeApiHeaders($organization->identity);
 
         $employeeData = $this->makeEmployeeData();
         $employee = $this->storeEmployee($organization, $employeeData, $headers);
@@ -85,7 +85,7 @@ class EmployeeTest extends TestCase
     {
         $organization = Organization::where('name', 'Nijmegen')->first();
         $this->assertNotNull($organization);
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($organization->identity));
+        $headers = $this->makeApiHeaders($organization->identity);
 
         $employeeData = $this->makeEmployeeData();
         $employee = $this->storeEmployee($organization, $employeeData, $headers);
@@ -103,7 +103,7 @@ class EmployeeTest extends TestCase
     {
         $organization = Organization::where('name', 'Nijmegen')->first();
         $this->assertNotNull($organization);
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($organization->identity));
+        $headers = $this->makeApiHeaders($organization->identity);
 
         $this->storeEmployee($organization, $this->makeEmployeeData(), $headers);
     }
@@ -114,7 +114,7 @@ class EmployeeTest extends TestCase
     {
         $organization = Organization::where('name', 'Nijmegen')->first();
         $this->assertNotNull($organization);
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($organization->identity));
+        $headers = $this->makeApiHeaders($organization->identity);
 
         $employeeData = $this->makeEmployeeData();
         $employee = $this->storeEmployee($organization, $employeeData, $headers);

--- a/tests/Feature/FundCriteriaTest.php
+++ b/tests/Feature/FundCriteriaTest.php
@@ -16,6 +16,7 @@ use Illuminate\Testing\TestResponse;
 use Tests\TestCase;
 use Tests\Traits\FundFormulaProductTestTrait;
 use Tests\Traits\MakesTestFundProviders;
+use Tests\Traits\MakesTestFundRequests;
 use Tests\Traits\MakesTestFunds;
 use Tests\Traits\MakesTestIdentities;
 use Tests\Traits\MakesTestOrganizations;
@@ -26,14 +27,10 @@ class FundCriteriaTest extends TestCase
     use MakesTestFunds;
     use MakesTestIdentities;
     use DatabaseTransactions;
+    use MakesTestFundRequests;
     use MakesTestOrganizations;
     use MakesTestFundProviders;
     use FundFormulaProductTestTrait;
-
-    /**
-     * @var string
-     */
-    protected string $apiUrlFundRequest = '/api/v1/platform/funds/%s/requests';
 
     /**
      * @var string
@@ -377,7 +374,7 @@ class FundCriteriaTest extends TestCase
         $fund = $this->makeTestFund($organization);
 
         $identityHeaders = [
-            ...$this->makeApiHeaders($this->makeIdentityProxy($identity)),
+            ...$this->makeApiHeaders($identity),
             'Client-Type' => 'webshop',
             'Client-Key' => $fund->fund_config->implementation->key,
         ];
@@ -419,7 +416,7 @@ class FundCriteriaTest extends TestCase
         $fund = $this->makeTestFund($organization, [], ['csv_primary_key' => 'bsn']);
 
         $identityHeaders = [
-            ...$this->makeApiHeaders($this->makeIdentityProxy($identity)),
+            ...$this->makeApiHeaders($identity),
             'Client-Type' => 'webshop',
             'Client-Key' => $fund->fund_config->implementation->key,
         ];
@@ -649,26 +646,6 @@ class FundCriteriaTest extends TestCase
     }
 
     /**
-     * @param Identity $identity
-     * @param Fund $fund
-     * @param mixed $records
-     * @param bool $validate
-     * @return TestResponse
-     */
-    protected function makeFundRequest(
-        Identity $identity,
-        Fund $fund,
-        mixed $records,
-        bool $validate,
-    ): TestResponse {
-        $url = sprintf($this->apiUrlFundRequest, $fund->id) . ($validate ? "/validate" : "");
-        $proxy = $this->makeIdentityProxy($identity);
-        $identity->setBsnRecord('123456789');
-
-        return $this->postJson($url, compact('records'), $this->makeApiHeaders($proxy));
-    }
-
-    /**
      * @param array $criteria
      * @param Fund $fund
      * @return TestResponse
@@ -679,6 +656,6 @@ class FundCriteriaTest extends TestCase
 
         return $this->patchJson($url, [
             'criteria' => [$criteria],
-        ], $this->makeApiHeaders($this->makeIdentityProxy($fund->organization?->identity)));
+        ], $this->makeApiHeaders($fund->organization?->identity));
     }
 }

--- a/tests/Feature/FundRequestEmailLogsTest.php
+++ b/tests/Feature/FundRequestEmailLogsTest.php
@@ -74,13 +74,11 @@ class FundRequestEmailLogsTest extends TestCase
 
     /**
      * @param Fund $fund
-     * @param Identity $requesterIdentity
+     * @param Identity $requester
      * @return FundRequest
      */
-    protected function makeFundRequest(Fund $fund, Identity $requesterIdentity): FundRequest
+    protected function makeFundRequest(Fund $fund, Identity $requester): FundRequest
     {
-        $requesterIdentityAuth = $this->makeApiHeaders($this->makeIdentityProxy($requesterIdentity));
-
         // make the fund request
         $response = $this->postJson("/api/v1/platform/funds/$fund->id/requests", [
             'records' => [[
@@ -88,7 +86,7 @@ class FundRequestEmailLogsTest extends TestCase
                 'value' => 5,
                 'files' => [],
             ]]
-        ], $requesterIdentityAuth);
+        ], $this->makeApiHeaders($requester));
 
         $response->assertSuccessful();
         $fundRequest = FundRequest::find($response->json('data.id'));
@@ -110,7 +108,7 @@ class FundRequestEmailLogsTest extends TestCase
         // assert email log exists
         $response = $this->getJson(
             "/api/v1/platform/organizations/$organization->id/fund-requests/$fundRequest->id/email-logs",
-            $this->makeApiHeaders($this->makeIdentityProxy($organization->identity)),
+            $this->makeApiHeaders($organization->identity),
         );
 
         $response->assertSuccessful();
@@ -141,7 +139,7 @@ class FundRequestEmailLogsTest extends TestCase
                 'fund_request_record_id' => $fundRequestRecord->id,
                 'question' => $questionToken,
             ],
-            $this->makeApiHeaders($this->makeIdentityProxy($organization->identity)),
+            $this->makeApiHeaders($organization->identity),
         );
 
         $response->assertSuccessful();
@@ -163,7 +161,7 @@ class FundRequestEmailLogsTest extends TestCase
         // assert email log exists
         $response = $this->getJson(
             "/api/v1/platform/organizations/$organization->id/fund-requests/$fundRequest->id/email-logs",
-            $this->makeApiHeaders($this->makeIdentityProxy($organization->identity)),
+            $this->makeApiHeaders($organization->identity),
         );
 
         $response->assertSuccessful();
@@ -195,7 +193,7 @@ class FundRequestEmailLogsTest extends TestCase
                 "/records/$fundRequestRecord->id/decline",
             ]),
             [ 'note' => $noteToken ],
-            $this->makeApiHeaders($this->makeIdentityProxy($organization->identity)),
+            $this->makeApiHeaders($organization->identity),
         );
 
         $response->assertSuccessful();
@@ -217,7 +215,7 @@ class FundRequestEmailLogsTest extends TestCase
         // assert email log exists
         $response = $this->getJson(
             "/api/v1/platform/organizations/$organization->id/fund-requests/$fundRequest->id/email-logs",
-            $this->makeApiHeaders($this->makeIdentityProxy($organization->identity)),
+            $this->makeApiHeaders($organization->identity),
         );
 
         $response->assertSuccessful();
@@ -244,7 +242,7 @@ class FundRequestEmailLogsTest extends TestCase
         $response = $this->patch(
             "/api/v1/platform/organizations/$organization->id/fund-requests/$fundRequest->id/approve",
             [],
-            $this->makeApiHeaders($this->makeIdentityProxy($organization->identity)),
+            $this->makeApiHeaders($organization->identity),
         );
 
         $response->assertSuccessful();
@@ -262,7 +260,7 @@ class FundRequestEmailLogsTest extends TestCase
         // assert email log exists
         $response = $this->getJson(
             "/api/v1/platform/organizations/$organization->id/fund-requests/$fundRequest->id/email-logs",
-            $this->makeApiHeaders($this->makeIdentityProxy($organization->identity)),
+            $this->makeApiHeaders($organization->identity),
         );
 
         $response->assertSuccessful();
@@ -286,7 +284,7 @@ class FundRequestEmailLogsTest extends TestCase
         $response = $this->patch(
             "/api/v1/platform/organizations/$organization->id/fund-requests/$fundRequest->id/disregard",
             [ 'notify' => $notify ],
-            $this->makeApiHeaders($this->makeIdentityProxy($organization->identity)),
+            $this->makeApiHeaders($organization->identity),
         );
 
         $response->assertSuccessful();
@@ -306,7 +304,7 @@ class FundRequestEmailLogsTest extends TestCase
         // assert email log exists
         $response = $this->getJson(
             "/api/v1/platform/organizations/$organization->id/fund-requests/$fundRequest->id/email-logs",
-            $this->makeApiHeaders($this->makeIdentityProxy($organization->identity)),
+            $this->makeApiHeaders($organization->identity),
         );
 
         $response->assertSuccessful();

--- a/tests/Feature/FundRequestTest.php
+++ b/tests/Feature/FundRequestTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Employee;
+use App\Models\Fund;
+use App\Models\FundRequest;
+use App\Models\Identity;
+use App\Models\Organization;
+use App\Services\MediaService\Traits\UsesMediaService;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use Tests\Traits\MakesTestFundRequests;
+use Tests\Traits\MakesTestFunds;
+use Tests\Traits\MakesTestIdentities;
+use Tests\Traits\MakesTestOrganizations;
+use Tests\Traits\MakesTestRecords;
+
+class FundRequestTest extends TestCase
+{
+    use UsesMediaService;
+    use DatabaseTransactions;
+    use WithFaker;
+    use MakesTestFunds;
+    use MakesTestOrganizations;
+    use MakesTestIdentities;
+    use MakesTestRecords;
+    use MakesTestFundRequests;
+
+    /**
+     * @return void
+     */
+    public function testFundApplyWithOnlyProductFormula()
+    {
+        $requester = $this->makeIdentity();
+        $fund = $this->createFundAndAddProviderWithProducts(1);
+
+        $fund->fund_formulas()->delete();
+        $fund->updateFormulaProducts([
+            ['product_id' => $fund->fund_providers[0]->organization->products[0]->id],
+        ]);
+
+        $this->setCriteriaAndMakeFundRequest($requester, $fund, [
+            'children_nth' => 10,
+        ]);
+
+        $this->assertEquals(1, $requester->fresh()->vouchers()->count());
+    }
+
+    /**
+     * @return void
+     */
+    public function testFundApplyWithOnlyProductFormulaAndMultiplier()
+    {
+        $requester = $this->makeIdentity();
+        $fund = $this->createFundAndAddProviderWithProducts(2);
+
+        $fund->fund_formulas()->delete();
+        $fund->updateFormulaProducts([[
+            'product_id' => $fund->fund_providers[0]->organization->products[0]->id,
+        ], [
+            'product_id' => $fund->fund_providers[0]->organization->products[1]->id,
+            'record_type_key_multiplier' => 'children_nth',
+        ]]);
+
+        $this->setCriteriaAndMakeFundRequest($requester, $fund, [
+            'children_nth' => 10,
+        ]);
+
+        $this->assertEquals(11, $requester->fresh()->vouchers()->count());
+    }
+
+    /**
+     * @return void
+     */
+    public function testFundApplyWithFormulaAndProductFormula()
+    {
+        $requester = $this->makeIdentity();
+        $fund = $this->createFundAndAddProviderWithProducts(2);
+
+        $fund->fund_formulas()->delete();
+        $fund->fund_formulas()->create([
+            'type' => 'fixed',
+            'amount' => 10,
+        ]);
+
+        $fund->updateFormulaProducts([[
+            'product_id' => $fund->fund_providers[0]->organization->products[0]->id,
+        ], [
+            'product_id' => $fund->fund_providers[0]->organization->products[1]->id,
+            'record_type_key_multiplier' => 'children_nth',
+        ]]);
+
+        $this->setCriteriaAndMakeFundRequest($requester, $fund, [
+            'children_nth' => 10,
+        ]);
+
+        $this->assertEquals(12, $requester->fresh()->vouchers()->count());
+    }
+
+    /**
+     * @return void
+     */
+    public function testFundApplyCustomAmount()
+    {
+        $requester = $this->makeIdentity();
+        $fund = $this->createFundAndAddProviderWithProducts(2);
+
+        $fund->fund_formulas()->delete();
+        $fund->fund_formulas()->create([
+            'type' => 'fixed',
+            'amount' => 10,
+        ]);
+
+        $fund->updateFormulaProducts([[
+            'product_id' => $fund->fund_providers[0]->organization->products[0]->id,
+        ]]);
+
+        $this->setSimpleFundCriteria($fund, [
+            'children_nth' => 10,
+        ]);
+
+        $voucher = $fund->makeVoucher($requester, amount: 100);
+
+        $this->assertEquals(100, $voucher->amount);
+        $this->assertEquals(1, $requester->fresh()->vouchers()->count());
+    }
+
+    /**
+     * @param Identity $requester
+     * @param Fund $fund
+     * @param array $records
+     * @return void
+     */
+    protected function setCriteriaAndMakeFundRequest(Identity $requester, Fund $fund, array $records): void
+    {
+        $this->setSimpleFundCriteria($fund, $records);
+
+        $recordsList = collect($records)->map(function (string|int $value, string $key) use ($fund) {
+            return $this->makeRequestCriterionValue($fund, $key, $value);
+        });
+
+        $response = $this->makeFundRequest($requester, $fund, $recordsList, false);
+        $response->assertSuccessful();
+
+        /** @var Employee $employee */
+        $fundRequest = FundRequest::find($response->json('data.id'));
+        $employee = $fundRequest->fund->organization->employees->first();
+
+        $this->assertNotNull($fundRequest);
+        $this->assertNotNull($employee);
+
+        $fundRequest->assignEmployee($employee);
+        $fundRequest->approve();
+        $fundRequest->refresh();
+
+        $this->assertTrustedRecords($requester, $fund, $records);
+    }
+
+    /**
+     * @param Fund $fund
+     * @param array $criteria
+     * @return Fund
+     */
+    protected function setSimpleFundCriteria(Fund $fund, array $criteria): Fund
+    {
+        return $fund->syncCriteria(collect($criteria)->map(fn (string|int $value, string $key) => [
+            'show_attachment' => false,
+            'record_type_key' => $key,
+            'operator' => '=',
+            'value' => $value,
+        ])->toArray());
+    }
+
+    /**
+     * @param int $productsCount
+     * @return Fund
+     */
+    protected function createFundAndAddProviderWithProducts(int $productsCount): Fund
+    {
+        $organization = $this->makeTestOrganization($this->makeIdentity());
+        $fund = $this->makeTestFund($organization);
+        $organization->forceFill([
+            'fund_request_resolve_policy' => Organization::FUND_REQUEST_POLICY_AUTO_REQUESTED,
+        ])->save();
+
+        $fund->fund_config->update([
+            'email_required' => false,
+            'contact_info_required' => false,
+        ]);
+
+        $provider = $this->makeTestFundProvider($this->makeTestOrganization($this->makeIdentity()), $fund);
+        $this->makeTestProducts($provider->organization, $productsCount);
+        $provider->organization->refresh();
+
+        return $fund->refresh();
+    }
+}

--- a/tests/Feature/PayoutsTest.php
+++ b/tests/Feature/PayoutsTest.php
@@ -297,6 +297,20 @@ class PayoutsTest extends TestCase
     /**
      * @return void
      */
+    public function testPayoutFundRequestUsingCustomAmountWhenFormulaIsMissing(): void
+    {
+        $fundRequest = $this->makePayoutFundRequest();
+        $fundRequest->fund->fund_formulas()->delete();
+
+        $fundRequest = $this->approveFundRequest($fundRequest, ['amount' => 75]);
+        $this->assertFundRequestGeneratedPayout($fundRequest);
+
+        self::assertEquals(75, $fundRequest->vouchers[0]?->transactions[0]?->amount);
+    }
+
+    /**
+     * @return void
+     */
     public function testPayoutFundRequestUsingCustomPreset(): void
     {
         $fundRequest = $this->makePayoutFundRequest();
@@ -527,7 +541,7 @@ class PayoutsTest extends TestCase
     protected function makeFundRequest(Fund $fund, array $records): FundRequest
     {
         $requester = $this->makeIdentity($this->makeUniqueEmail());
-        $requesterIdentityAuth = $this->makeApiHeaders($this->makeIdentityProxy($requester));
+        $requesterIdentityAuth = $this->makeApiHeaders($requester);
 
         $requester->setBsnRecord('123456789');
 

--- a/tests/Feature/ReimbursementTest.php
+++ b/tests/Feature/ReimbursementTest.php
@@ -260,7 +260,7 @@ class ReimbursementTest extends TestCase
         Employee $employee,
     ): void {
         $endpoint = "/api/v1/platform/organizations/$employee->organization_id/reimbursements";
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($employee->identity));
+        $headers = $this->makeApiHeaders($employee->identity);
 
         $response = $this->getJson("$endpoint?" . http_build_query([
             'q' => $reimbursement->voucher->identity->email,
@@ -279,7 +279,7 @@ class ReimbursementTest extends TestCase
         Employee $employee,
     ): void {
         $endpoint = "/api/v1/platform/organizations/$employee->organization_id/reimbursements";
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($employee->identity));
+        $headers = $this->makeApiHeaders($employee->identity);
 
         $response = $this->getJson("$endpoint?" . http_build_query([
             'q' => $reimbursement->voucher->identity->email,
@@ -298,7 +298,7 @@ class ReimbursementTest extends TestCase
         Employee $employee
     ): void {
         $endpoint = "/api/v1/platform/organizations/$employee->organization_id/reimbursements";
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($employee->identity));
+        $headers = $this->makeApiHeaders($employee->identity);
 
         $response = $this->postJson("$endpoint/$reimbursement->id/assign", [], $headers);
         $response->assertSuccessful();
@@ -316,7 +316,7 @@ class ReimbursementTest extends TestCase
         Employee $employee
     ): void {
         $endpoint = "/api/v1/platform/organizations/$employee->organization_id/reimbursements";
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($employee->identity));
+        $headers = $this->makeApiHeaders($employee->identity);
 
         $response = $this->postJson("$endpoint/$reimbursement->id/resign", [], $headers);
         $response->assertSuccessful();
@@ -335,7 +335,7 @@ class ReimbursementTest extends TestCase
         Employee $employee,
         bool $approve
     ): void {
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($employee->identity));
+        $headers = $this->makeApiHeaders($employee->identity);
         $assertState = $approve ? $reimbursement::STATE_APPROVED : $reimbursement::STATE_DECLINED;
 
         $endpoint = "/api/v1/platform/organizations/$employee->organization_id/reimbursements";
@@ -358,7 +358,7 @@ class ReimbursementTest extends TestCase
         Employee $employee,
         bool $approve
     ): void {
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($employee->identity));
+        $headers = $this->makeApiHeaders($employee->identity);
 
         $endpoint = "/api/v1/platform/organizations/$employee->organization_id/reimbursements";
         $endpoint = "$endpoint/$reimbursement->id/" . ($approve ? 'approve' : 'decline');
@@ -379,7 +379,7 @@ class ReimbursementTest extends TestCase
         Employee $unassignedEmployee
     ): void {
         $endpoint = "/api/v1/platform/organizations/$employee->organization_id/reimbursements";
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($employee->identity));
+        $headers = $this->makeApiHeaders($employee->identity);
         $headersUnassigned = $this->makeApiHeaders($this->makeIdentityProxy($unassignedEmployee->identity));
 
         // assert unassigned employee can't add notes

--- a/tests/Feature/VoucherTest.php
+++ b/tests/Feature/VoucherTest.php
@@ -310,7 +310,7 @@ class VoucherTest extends TestCase
                 };
             }
 
-            $headers = $this->makeApiHeaders($this->makeIdentityProxy($voucher->fund->organization->identity));
+            $headers = $this->makeApiHeaders($voucher->fund->organization->identity);
             $url = $this->getSponsorApiUrl($voucher, '/assign');
 
             $response = $this->patch($url, $params, $headers);
@@ -342,7 +342,7 @@ class VoucherTest extends TestCase
     {
         $voucher->refresh();
 
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($voucher->fund->organization->identity));
+        $headers = $this->makeApiHeaders($voucher->fund->organization->identity);
         $url = $this->getSponsorApiUrl($voucher, '/activate');
 
         $response = $this->patch($url, ['note' => $this->faker->sentence()], $headers);
@@ -359,7 +359,7 @@ class VoucherTest extends TestCase
     {
         $voucher->refresh();
 
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($voucher->fund->organization->identity));
+        $headers = $this->makeApiHeaders($voucher->fund->organization->identity);
         $url = $this->getSponsorApiUrl($voucher, '/deactivate');
 
         $response = $this->patch($url, ['note' => $this->faker->sentence()], $headers);
@@ -377,7 +377,7 @@ class VoucherTest extends TestCase
         $voucher->refresh();
 
         if ($voucher->isDeactivated()) {
-            $headers = $this->makeApiHeaders($this->makeIdentityProxy($voucher->fund->organization->identity));
+            $headers = $this->makeApiHeaders($voucher->fund->organization->identity);
             $url = $this->getSponsorApiUrl($voucher, '/activate');
 
             $response = $this->patch($url, ['note' => $this->faker->sentence()], $headers);
@@ -398,7 +398,7 @@ class VoucherTest extends TestCase
 
         if ($voucher->fund->isTypeSubsidy()) {
             $limitMultiplier = $voucher->limit_multiplier + random_int(1, 10);
-            $headers = $this->makeApiHeaders($this->makeIdentityProxy($voucher->fund->organization->identity));
+            $headers = $this->makeApiHeaders($voucher->fund->organization->identity);
             $url = $this->getSponsorApiUrl($voucher);
 
             $response = $this->patch($url, ['limit_multiplier' => $limitMultiplier], $headers);
@@ -421,7 +421,7 @@ class VoucherTest extends TestCase
         $voucher->refresh();
 
         if (!$voucher->is_granted && !$voucher->activation_code && !$voucher->isDeactivated()) {
-            $headers = $this->makeApiHeaders($this->makeIdentityProxy($voucher->fund->organization->identity));
+            $headers = $this->makeApiHeaders($voucher->fund->organization->identity);
             $url = $this->getSponsorApiUrl($voucher, '/activation-code');
 
             $response = $this->patch($url, [], $headers);
@@ -467,7 +467,7 @@ class VoucherTest extends TestCase
         $amount = random_int(1, round($voucher->amount_available / 2));
         $organization = $voucher->fund->organization;
 
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($organization->identity));
+        $headers = $this->makeApiHeaders($organization->identity);
         $url = sprintf($this->apiOrganizationUrl . '/sponsor/transactions', $organization->id);
 
         $response = $this->post($url, [
@@ -513,7 +513,7 @@ class VoucherTest extends TestCase
         $this->assertNotNull($fundProvider->organization);
         $provider = $fundProvider->organization;
 
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($organization->identity));
+        $headers = $this->makeApiHeaders($organization->identity);
         $url = sprintf($this->apiOrganizationUrl . '/sponsor/transactions', $organization->id);
 
         $response = $this->post($url, [
@@ -570,7 +570,7 @@ class VoucherTest extends TestCase
         ]);
         $amount = random_int(1, round($maxAmount / 2));
 
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($organization->identity));
+        $headers = $this->makeApiHeaders($organization->identity);
         $url = sprintf($this->apiOrganizationUrl . '/sponsor/transactions', $organization->id);
         $params = [
             'voucher_id' => $voucher->id,
@@ -659,7 +659,7 @@ class VoucherTest extends TestCase
         $card = $voucher->physical_cards()->first();
         $this->assertNotNull($card);
 
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($voucher->fund->organization->identity));
+        $headers = $this->makeApiHeaders($voucher->fund->organization->identity);
         $url = $this->getSponsorApiUrlPhysicalCards($voucher, "/$card->id");
 
         $response = $this->delete($url, [], $headers);
@@ -677,7 +677,7 @@ class VoucherTest extends TestCase
     protected function assertAbilityCreatePhysicalCardRequest(Voucher $voucher): void
     {
         $startDate = now();
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($voucher->fund->organization->identity));
+        $headers = $this->makeApiHeaders($voucher->fund->organization->identity);
 
         $url = sprintf(
             $this->apiOrganizationUrl . '/sponsor/vouchers/%s/physical-card-requests',

--- a/tests/Feature/VoucherTransactionNoteTest.php
+++ b/tests/Feature/VoucherTransactionNoteTest.php
@@ -41,7 +41,7 @@ class VoucherTransactionNoteTest extends TestCase
         $voucher = $fund->makeVoucher($this->makeIdentity());
         $address = $voucher->token_without_confirmation->address;
 
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($providerOrganization->identity));
+        $headers = $this->makeApiHeaders($providerOrganization->identity);
         $response = $this->post("/api/v1/platform/provider/vouchers/$address/transactions", [
             'note' => $this->note,
             'amount' => round($voucher->amount_available / 2),

--- a/tests/Traits/MakesTestFundRequests.php
+++ b/tests/Traits/MakesTestFundRequests.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Traits;
+
+use App\Models\Fund;
+use App\Models\Identity;
+use Illuminate\Testing\TestResponse;
+
+trait MakesTestFundRequests
+{
+    /**
+     * @param Identity $identity
+     * @param Fund $fund
+     * @param mixed $records
+     * @param bool $validate
+     * @return TestResponse
+     */
+    protected function makeFundRequest(
+        Identity $identity,
+        Fund $fund,
+        mixed $records,
+        bool $validate,
+    ): TestResponse {
+        $url = "/api/v1/platform/funds/$fund->id/requests" . ($validate ? "/validate" : "");
+        $proxy = $this->makeIdentityProxy($identity);
+        $identity->setBsnRecord('123456789');
+
+        return $this->postJson($url, compact('records'), $this->makeApiHeaders($proxy));
+    }
+}

--- a/tests/Traits/MakesTestRecords.php
+++ b/tests/Traits/MakesTestRecords.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Traits;
+
+use App\Models\Fund;
+use App\Models\Identity;
+use App\Models\Record;
+
+trait MakesTestRecords
+{
+    /**
+     * @param Identity $identity
+     * @param Identity $validator
+     * @param array $records
+     * @return void
+     */
+    protected function makeRecords(Identity $identity, Identity $validator, array $records): void
+    {
+        /** @var Record[] $records */
+        $records = $identity->addRecords($records);
+
+        foreach ($records as $record) {
+            $record->makeValidationRequest()->approve($validator);
+        }
+    }
+
+    /**
+     * @param Identity $identity
+     * @param Fund $fund
+     * @param array $records
+     * @return void
+     */
+    protected function assertTrustedRecords(Identity $identity, Fund $fund, array $records): void
+    {
+        foreach ($records as $key => $value) {
+            $this->assertEquals($value, $fund->getTrustedRecordOfType($identity->address, $key)?->value);
+        }
+    }
+}

--- a/tests/Traits/VoucherTestTrait.php
+++ b/tests/Traits/VoucherTestTrait.php
@@ -304,7 +304,7 @@ trait VoucherTestTrait
 
         $identity = $this->makeIdentity(null, ['bsn' => $voucher->voucher_relation->bsn]);
 
-        $headers = $this->makeApiHeaders($this->makeIdentityProxy($identity));
+        $headers = $this->makeApiHeaders($identity);
         $response = $this->post(sprintf($this->apiFundUrl . '/check', $voucher->fund_id), [], $headers);
         $response->assertSuccessful();
         $this->assertNotEmpty($response['vouchers']);


### PR DESCRIPTION
## Changes description
- Fixed known issue from the hotfix where payout fund requests that did not have a formula could not be approved 
- Updated autotests

## Developers checklist
- [x] **Autotests are passed locally**
- [x] **Migration rollback works** - if there is migration, check rollback
- [x] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
