### PR TITLE
fix providers state group filter

### DIFF
--- a/app/Http/Controllers/Api/Platform/Organizations/Sponsor/ProvidersController.php
+++ b/app/Http/Controllers/Api/Platform/Organizations/Sponsor/ProvidersController.php
@@ -41,7 +41,7 @@ class ProvidersController extends Controller
         });
 
         $query = OrganizationQuery::whereGroupState(
-            $query, $organization->funds->pluck('id')->all(), $request->get('state_group'),
+            $query, $organization, $request->get('state_group'),
         );
 
         $query = OrganizationQuery::orderProvidersBy($query, $organization, $request->only([

--- a/app/Scopes/Builders/FundQuery.php
+++ b/app/Scopes/Builders/FundQuery.php
@@ -25,6 +25,19 @@ class FundQuery
     }
 
     /**
+     * @param Builder|Relation|Fund $query
+     * @return Builder|Relation|Fund
+     */
+    public static function whereNotActiveFilter(
+        Builder|Relation|Fund $query
+    ): Builder|Relation|Fund {
+        return $query->where(function(Builder $builder) {
+            $builder->where('state', '!=', Fund::STATE_ACTIVE);
+            $builder->orWhereDate('end_date', '<', today());
+        });
+    }
+
+    /**
      * @param Builder $query
      * @param bool $includeArchived
      * @param bool $includeExternal


### PR DESCRIPTION
## Changes description
Fixed some providers visible on "Action required" and "Active" tab when they should not be visible.
•  "Action Required" tab, should show providers pending for at least one active funds.
•  "Active" tab, should show providers approved for at least one active funds.
•  "Inactive" tab, should show providers rejected for at least one active funds, or having at least one closed or archived fund of any state.

## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
