### PR TITLE
add rollback to ci

### DIFF
--- a/.github/workflows/unit_and_feature_tests.yml
+++ b/.github/workflows/unit_and_feature_tests.yml
@@ -28,25 +28,29 @@ jobs:
         run: cp -n .env.docker.dusk .env
 
       - name: Run docker compose up
-        run: docker compose --profile testing up -d
+        run: docker compose up -d
 
       - name: Set correct ownership of files in docker
         run: docker exec -u 0 forus-backend-app chown -R forus:forus /var/www/
 
       - name: Install dependencies
-        run: docker compose exec -T app bash -c "composer install"
+        run: docker compose exec -T app bash -c "composer install && composer dumpautoload"
 
-      - name: Create database structure
-        run: docker compose exec -T app bash -c "composer dumpautoload && php artisan migrate"
+      - name: Run migrations to create DB structure
+        run: docker compose exec -T app bash -c "php artisan migrate"
 
-      - name: Set app key
-        run: docker compose exec -T app bash -c "php artisan key:generate"
+      - name: Test rollback
+        run: |
+          docker compose exec -T app bash -c "
+          for i in {1..10} 
+          do
+            php artisan migrate:rollback --step=\$i;
+            php artisan migrate;
+          done"
 
-      - name: Run base seeders
-        run: docker compose exec -T app bash -c "php artisan db:seed"
-
-      - name: Generate test data
-        run: docker compose exec -T app php artisan test-data:seed
+      - name: Run seeders
+        run: |
+          docker compose exec -T app bash -c "php artisan key:generate && php artisan db:seed && php artisan test-data:seed"
 
       - name: Set debug based on input
         run: |


### PR DESCRIPTION
## Changes description
<!--- Describe shortly changes here if:
       - your solution differs from issue desrciption
       - there are advices from development side for QA or other stakeholders
-->
Sometimes we have bugs when new fields are missed in rollback script 
Example - https://github.com/teamforus/forus-backend/pull/2315
If it is missed, we will have see an error in migrations rollback on dev

I added rollback of last 10 migrations to feature tests in CI to check this scenario, it added approx 2 seconds to CI, what is minor amount

## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
