### PR TITLE
remove apostrophe from name generation in Reimbursement test

### DIFF
--- a/tests/Browser/ReimbursementTest.php
+++ b/tests/Browser/ReimbursementTest.php
@@ -701,7 +701,7 @@ class ReimbursementTest extends DuskTestCase
             'description' => $this->faker->text(600),
             'amount' => random_int(1, 10),
             'iban' => $this->faker()->iban('NL'),
-            'iban_name' => $this->faker()->firstName . ' ' . $this->faker()->lastName,
+            'iban_name' => str_replace("'", '', $this->faker()->firstName . ' ' . $this->faker()->lastName),
             'fund_name' => $voucher->fund->name,
             'sponsor_name' => $voucher->fund->organization->name,
             'voucher_id' => $voucher->id,


### PR DESCRIPTION
## Changes description
<!--- Describe shortly changes here if:
       - your solution differs from issue desrciption
       - there are advices from development side for QA or other stakeholders
-->
There was a case when faker was generating a name with apostrophe ', for example - O'Connor
This was failing backend validation of iban name

Example of build
https://github.com/teamforus/forus-backend/actions/runs/11050014075/job/30707102258?pr=2330#step:17:1530
Screenshot
![failure-Tests_Browser_ReimbursementTest_testApprovedReimbursementCreate-0](https://github.com/user-attachments/assets/939bf3bb-4bf8-44df-bdd6-0f17b3319741)


## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
