### PR TITLE
Get same branch from frontend for browser CI tests

### DIFF
--- a/.github/workflows/browser_tests.yml
+++ b/.github/workflows/browser_tests.yml
@@ -108,7 +108,7 @@ jobs:
         run: docker compose exec -T app bash -c "php artisan dusk:chrome"
 
       - name: --- RUN BROWSER TESTS ---
-        run: docker compose exec -T app bash -c "php artisan dusk --debug --testdox"
+        run: docker compose exec -T app bash -c "php artisan dusk tests/Browser/AuthenticationTest.php --debug --testdox"
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/browser_tests.yml
+++ b/.github/workflows/browser_tests.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
 
-  build:
+  test_ui:
 
     runs-on: ubuntu-latest
     defaults:
@@ -108,7 +108,7 @@ jobs:
         run: docker compose exec -T app bash -c "php artisan dusk:chrome"
 
       - name: --- RUN BROWSER TESTS ---
-        run: docker compose exec -T app bash -c "php artisan dusk tests/Browser/AuthenticationTest.php --debug --testdox"
+        run: docker compose exec -T app bash -c "php artisan dusk --debug --testdox"
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/browser_tests.yml
+++ b/.github/workflows/browser_tests.yml
@@ -56,15 +56,31 @@ jobs:
       - name: Generate test data
         run: docker compose exec -T app php artisan test-data:seed
 
-      - name: "Set frontend branch value for manual and auto runs"
+      - name: "Set frontend branch value for manual, auto runs, and PR CI"
         run: |
-          if [[ -z "${{ github.event.inputs.frontend_branch }}" ]]; then
-            echo "Frontend branch param. is not set, setting default 'develop'"
-            echo "FRONTEND_BRANCH=develop" >> $GITHUB_ENV
+          FRONTEND_BRANCH=""
+          
+          if [[ -n "${{ github.event.inputs.frontend_branch }}" ]]; then
+            FRONTEND_BRANCH=${{ github.event.inputs.frontend_branch }}
+            echo "Frontend branch param is set: $FRONTEND_BRANCH"
           else
-            echo "Frontend branch param is set: ${{ github.event.inputs.frontend_branch }}"
-            echo "FRONTEND_BRANCH=${{ github.event.inputs.frontend_branch }}" >> $GITHUB_ENV
+            if [[ -n "${{ github.event.pull_request.head.ref }}" ]]; then
+              FRONTEND_BRANCH="${{ github.event.pull_request.head.ref }}"
+              echo "Trying to set FRONTEND_BRANCH from PR source branch: $FRONTEND_BRANCH"
+
+              if [[ $(git ls-remote --heads https://github.com/teamforus/forus-frontend-react.git "$FRONTEND_BRANCH") ]]; then
+                echo "Branch $FRONTEND_BRANCH exists in frontend repo, using it"
+              else
+                echo "Branch does not exist in 'forus-frontend', defaulting to 'develop'."
+                FRONTEND_BRANCH="develop"
+              fi
+            else
+              echo "PR source branch is not set, defaulting to 'develop'."
+              FRONTEND_BRANCH="develop"
+            fi
           fi
+          
+          echo "FRONTEND_BRANCH=$FRONTEND_BRANCH" >> "$GITHUB_ENV"
 
       - name: Check out forus-frontend-react repo
         uses: actions/checkout@v4

--- a/.github/workflows/unit_and_feature_tests.yml
+++ b/.github/workflows/unit_and_feature_tests.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
 
-  build:
+  test_features:
 
     runs-on: ubuntu-latest
     defaults:

--- a/tests/Browser/Traits/HasFrontendActions.php
+++ b/tests/Browser/Traits/HasFrontendActions.php
@@ -96,7 +96,7 @@ trait HasFrontendActions
         $browser->element('@userProfile')->click();
 
         $browser->waitFor('@btnUserLogout')->waitFor('@btnUserLogout', 20);
-        $browser->element('@btnUserLogout')->click();
+        $browser->pause(500)->element('@btnUserLogout')->click();
 
         $browser->waitUntilMissing('@userProfile');
     }


### PR DESCRIPTION
## Changes description
<!--- Describe shortly changes here if:
       - your solution differs from issue desrciption
       - there are advices from development side for QA or other stakeholders
-->

Browser tests build is automatically executed in PR creation in branch feature.1
 - Build clones backend branch feature.1
 - Build checks if there is branch feature.1 in the frontend repo:
     - if there is - it uses it for cloning frontend repo
     - if there isn't - it uses develop branch
If tests build was executed manually, then it uses frontend branch parameter

## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
