### PR TITLE
Add index on email_logs.mailable

### DIFF
--- a/app/Services/MailDatabaseLoggerService/migrations/2024_10_11_101833_add_index_to_mailable_on_email_logs_table.php
+++ b/app/Services/MailDatabaseLoggerService/migrations/2024_10_11_101833_add_index_to_mailable_on_email_logs_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('email_logs', function (Blueprint $table) {
-             DB::statement('CREATE INDEX id_email_logs_mailable_event_log_id ON email_logs (mailable(255))');
+            $table->string('mailable', 250)->nullable()->index()->change();
         });
     }
 
@@ -26,7 +26,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('email_logs', function (Blueprint $table) {
-             $table->dropIndex('id_email_logs_mailable_event_log_id');
+             $table->dropIndex('email_logs_mailable_index');
         });
     }
 };

--- a/database/migrations/2024_10_11_101833_add_index_on_mailable_for_email_logs.php
+++ b/database/migrations/2024_10_11_101833_add_index_on_mailable_for_email_logs.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('email_logs', function (Blueprint $table) {
+             DB::statement('CREATE INDEX id_email_logs_mailable_event_log_id ON email_logs (mailable(255))');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('email_logs', function (Blueprint $table) {
+             $table->dropIndex('id_email_logs_mailable_event_log_id');
+        });
+    }
+};


### PR DESCRIPTION
## Changes description
<!--- Describe shortly changes here if:
       - your solution differs from issue desrciption
       - there are advices from development side for QA or other stakeholders
-->

To fix this slow query
```
SELECT count(*) as aggregate FROM `email_logs` WHERE `mailable` in ('App\\Mail\\Funds\\FundRequests\\FundRequestDeniedMail', 'App\\Mail\\Funds\\FundRequests\\FundRequestCreatedMail', 'App\\Mail\\Funds\\FundRequests\\FundRequestApprovedMail', 'App\\Mail\\Funds\\FundRequests\\FundRequestDisregardedMail', 'App\\Mail\\Funds\\FundRequestRecords\\FundRequestRecordDeclinedMail', 'App\\Mail\\Funds\\FundRequestClarifications\\FundRequestClarificationRequestedMail') and exists (SELECT * FROM `event_logs` WHERE `email_logs`.`event_log_id` = `event_logs`.`id` and ((`loggable_type` = 'fund_request' and `loggable_id` = 970) or (`loggable_type` = 'fund_request_record' and `loggable_id` in (SELECT `id` FROM `fund_request_records` WHERE `fund_request_id` = 970))))
```
added index on email_logs.mailable to speed up search `mailable` in

Note:
@dev-rminds there is a raw query added in migration, which differs from our usual migrations, the reason I added it:
- adding $table->index(['mailable(255)']); is not supported
- adding full-text index instead of regular of did not speed up query, because a full-text index is effective in match-against condition, while query above uses "in". in theory we can rewrite EmailLogQuery using match-against and then use full text index
 

## Developers checklist
- [x] **Autotests are passed locally**
- [x] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [x] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
