### PR TITLE
fix flaky test case

### DIFF
--- a/tests/Browser/ProductReservationTest.php
+++ b/tests/Browser/ProductReservationTest.php
@@ -61,7 +61,7 @@ class ProductReservationTest extends DuskTestCase
             $browser->visit($implementation->urlWebshop());
 
             $identity = $this->makeIdentity($this->makeUniqueEmail());
-            $provider = $this->makeProviderOrganization($this->makeIdentity($this->makeUniqueEmail()));
+            $provider = $this->makeTestProviderOrganization($this->makeIdentity($this->makeUniqueEmail()));
 
             $this->makeTestProductForReservation($provider);
 

--- a/tests/Feature/MollieExtraPaymentsTest.php
+++ b/tests/Feature/MollieExtraPaymentsTest.php
@@ -487,7 +487,7 @@ class MollieExtraPaymentsTest extends TestCase
             'state' => Voucher::STATE_ACTIVE
         ], 100));
 
-        $provider = $this->makeProviderOrganization($this->makeIdentity($this->makeUniqueEmail()));
+        $provider = $this->makeTestProviderOrganization($this->makeIdentity($this->makeUniqueEmail()));
         $product = $this->makeTestProductForReservation($provider);
         $fundProvider = $this->makeTestFundProvider($provider, $fund);
 

--- a/tests/Feature/VouchersProviderMeAppTest.php
+++ b/tests/Feature/VouchersProviderMeAppTest.php
@@ -41,7 +41,7 @@ class VouchersProviderMeAppTest extends TestCase
         $this->assertNotNull($voucher);
 
         $providerIdentity = $this->makeIdentity($this->makeUniqueEmail());
-        $provider = $this->makeProviderOrganization($providerIdentity);
+        $provider = $this->makeTestProviderOrganization($providerIdentity);
         $fundProvider = $this->makeTestFundProvider($provider, $fund);
 
         $this->assertNotNull($fundProvider);

--- a/tests/Traits/MakesTestFundProviders.php
+++ b/tests/Traits/MakesTestFundProviders.php
@@ -33,13 +33,14 @@ trait MakesTestFundProviders
 
     /**
      * @param Fund $fund
-     * @return Product[][]
+     * @param int $countProducts
+     * @return array
      */
-    protected function makeProviderAndProducts(Fund $fund): array
+    protected function makeProviderAndProducts(Fund $fund, int $countProducts = 5): array
     {
-        $approvedProducts = $this->makeProductsFundFund(5);
-        $emptyStockProducts = $this->makeProductsFundFund(5);
-        $unapprovedProducts = $this->makeProductsFundFund(5);
+        $approvedProducts = $this->makeProductsFundFund($countProducts);
+        $emptyStockProducts = $this->makeProductsFundFund($countProducts);
+        $unapprovedProducts = $this->makeProductsFundFund($countProducts);
 
         foreach ($approvedProducts as $product) {
             $this->addProductFundToFund($fund, $product, false);
@@ -85,7 +86,7 @@ trait MakesTestFundProviders
     protected function makeProductsFundFund(int $count): array
     {
         $identity = $this->makeIdentity($this->makeUniqueEmail('provider_'));
-        $provider = $this->makeTestOrganization($identity);
+        $provider = $this->makeTestProviderOrganization($identity);
         $products = $this->makeTestProducts($provider, $count);
 
         $this->assertNotEmpty($products, 'Products not created');
@@ -112,7 +113,7 @@ trait MakesTestFundProviders
             'organization_id' => $product->organization_id,
         ]);
 
-        if (!$approveGlobal) {
+        if (!$approveGlobal || $fund->isTypeSubsidy()) {
             $this->updateProductsRequest($fund, $fundProvider, [
                 'enable_products' => [[
                     'id' => $product->id,

--- a/tests/Traits/MakesTestFunds.php
+++ b/tests/Traits/MakesTestFunds.php
@@ -104,6 +104,23 @@ trait MakesTestFunds
 
     /**
      * @param Organization $organization
+     * @param array $fundData
+     * @param array $fundConfigsData
+     * @return Fund
+     */
+    protected function makeTestSubsidyFund(
+        Organization $organization,
+        array $fundData = [],
+        array $fundConfigsData = [],
+    ): Fund {
+        return $this->makeTestFund($organization, [
+            'type' => Fund::TYPE_SUBSIDIES,
+            ...$fundData,
+        ], $fundConfigsData);
+    }
+
+    /**
+     * @param Organization $organization
      * @param array $implementationData
      * @return Implementation
      */

--- a/tests/Traits/MakesTestOrganizations.php
+++ b/tests/Traits/MakesTestOrganizations.php
@@ -42,10 +42,11 @@ trait MakesTestOrganizations
      * @param array $organizationData
      * @return Organization
      */
-    public function makeProviderOrganization(Identity $identity, array $organizationData = []): Organization
+    public function makeTestProviderOrganization(Identity $identity, array $organizationData = []): Organization
     {
         $organization = $this->makeTestOrganization($identity, [
             'reservations_budget_enabled' => true,
+            'reservations_subsidy_enabled' => true,
             'reservation_allow_extra_payments' => true,
             ...$organizationData,
         ]);


### PR DESCRIPTION
## Changes description
Case: https://github.com/teamforus/forus-backend/actions/runs/12279849695/attempts/1
Fixed by creating a new fund during the test instead of using the seed data.

## Developers checklist
- [x] **Autotests are passed locally**
- [x] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
