### PR TITLE
add number to product vouchers and upload transactions by voucher number

### DIFF
--- a/app/Http/Controllers/Api/Platform/Organizations/Sponsor/TransactionsController.php
+++ b/app/Http/Controllers/Api/Platform/Organizations/Sponsor/TransactionsController.php
@@ -175,7 +175,7 @@ class TransactionsController extends Controller
             $validator = $request->validateRows($slice);
 
             if ($validator->passes()) {
-                $voucher = Voucher::find(Arr::get($item, 'voucher_id'));
+                $voucher = Voucher::firstWhere('number', Arr::get($item, 'voucher_number'));
 
                 $createdItems[] = $voucher->makeTransactionBySponsor($employee, [
                     'target_iban' => $item['direct_payment_iban'],

--- a/app/Models/Voucher.php
+++ b/app/Models/Voucher.php
@@ -210,12 +210,6 @@ class Voucher extends BaseModel
     public const string STATE_PENDING = 'pending';
     public const string STATE_DEACTIVATED = 'deactivated';
 
-    public const array EVENTS_TRANSACTION = [
-        self::EVENT_TRANSACTION,
-        self::EVENT_TRANSACTION_PRODUCT,
-        self::EVENT_TRANSACTION_SUBSIDY,
-    ];
-
     public const array EVENTS_CREATED = [
         self::EVENT_CREATED_BUDGET,
         self::EVENT_CREATED_PRODUCT,
@@ -1086,14 +1080,15 @@ class Voucher extends BaseModel
         ])));
 
         $voucher = self::create([
-            'product_reservation_id'    => $productReservation?->id,
-            'identity_id'               => $this->identity_id,
-            'parent_id'                 => $this->id,
-            'fund_id'                   => $this->fund_id,
-            'product_id'                => $product->id,
-            'amount'                    => $productReservation->amount ?? $product->price,
-            'returnable'                => false,
-            'expire_at'                 => $voucherExpireAt
+            'number' => self::makeUniqueNumber(),
+            'amount' => $productReservation->amount ?? $product->price,
+            'fund_id' => $this->fund_id,
+            'expire_at' => $voucherExpireAt,
+            'parent_id' => $this->id,
+            'returnable' => false,
+            'product_id' => $product->id,
+            'identity_id' => $this->identity_id,
+            'product_reservation_id' => $productReservation?->id,
         ]);
 
         VoucherCreated::dispatch($voucher, !$productReservation, !$productReservation);
@@ -1133,6 +1128,24 @@ class Voucher extends BaseModel
     public function isDeactivated(): bool
     {
         return $this->state === self::STATE_DEACTIVATED;
+    }
+
+    /**
+     * @return bool
+     * @noinspection PhpUnused
+     */
+    public function isVoucherType(): bool
+    {
+        return $this->voucher_type === self::VOUCHER_TYPE_VOUCHER;
+    }
+
+    /**
+     * @return bool
+     * @noinspection PhpUnused
+     */
+    public function isPayoutType(): bool
+    {
+        return $this->voucher_type === self::VOUCHER_TYPE_PAYOUT;
     }
 
     /**

--- a/app/Policies/VoucherPolicy.php
+++ b/app/Policies/VoucherPolicy.php
@@ -262,7 +262,10 @@ class VoucherPolicy
      */
     public function show(Identity $identity, Voucher $voucher) : bool
     {
-        return $identity->id === $voucher->identity_id;
+        return
+            ($identity->id === $voucher->identity_id) &&
+            $voucher->isVoucherType() &&
+            !$voucher->product_reservation;
     }
 
     /**

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -100,8 +100,13 @@ class RouteServiceProvider extends ServiceProvider
 
         $router->bind('voucher_number_or_address', static function ($value) {
             return $value ? Voucher::where(function(Builder $builder) use ($value) {
-                $builder->where('number', $value);
-                $builder->orWhereRelation('tokens', 'address', $value);
+                $builder->whereDoesntHave('product_reservation');
+                $builder->where('voucher_type', Voucher::VOUCHER_TYPE_VOUCHER);
+
+                $builder->where(function(Builder $builder) use ($value) {
+                    $builder->where('number', $value);
+                    $builder->orWhereRelation('tokens', 'address', $value);
+                });
             })->firstOrFail() : null;
         });
 

--- a/database/migrations/2024_11_04_113416_add_unique_key_to_number_on_vouchers_table.php
+++ b/database/migrations/2024_11_04_113416_add_unique_key_to_number_on_vouchers_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\Voucher;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('vouchers', function (Blueprint $table) {
+            $table->unique('number');
+        });
+
+        while (($list = DB::table('vouchers')->whereNull('number')->get())->isNotEmpty()) {
+            $list->each(function ($val) {
+                /** @var Voucher|object $val */
+                $number = Voucher::makeUniqueNumber();
+
+                DB::table('vouchers')->where('id', $val->id)->update([ 'number' => $number ]);
+
+                DB::table('event_logs')
+                    ->where('loggable_type', 'voucher')
+                    ->where('loggable_id', $val->id)
+                    ->update([ 'data->voucher_number' => $number ]);
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('vouchers', function (Blueprint $table) {
+            $table->dropUnique('vouchers_number_unique');
+        });
+    }
+};

--- a/tests/Browser/VoucherTransactionBatchTest.php
+++ b/tests/Browser/VoucherTransactionBatchTest.php
@@ -146,12 +146,12 @@ class VoucherTransactionBatchTest extends DuskTestCase
         $handle = fopen($filename, 'w');
 
         fputcsv($handle, [
-            'voucher_id', 'amount', 'direct_payment_iban', 'direct_payment_name', 'uid', 'note',
+            'voucher_number', 'amount', 'direct_payment_iban', 'direct_payment_name', 'uid', 'note',
         ]);
 
         for ($i = 1; $i <= $this->transactionPerVoucher; $i++) {
             fputcsv($handle, [
-                'voucher_id' => $voucher->id,
+                'voucher_number' => $voucher->number,
                 'amount' => $voucher->amount_available / $this->transactionPerVoucher,
                 'direct_payment_iban' => $this->faker()->iban('NL'),
                 'direct_payment_name' => $this->faker()->firstName . ' ' . $this->faker()->lastName,


### PR DESCRIPTION
## Changes description
All voucher types should now have a unique number.
Uploading transactions bulk should now use voucher_number instead of voucher_id.

## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
