### PR TITLE
disable transaction description reservation names by default

### DIFF
--- a/database/migrations/2025_03_18_101811_disable_bank_reservation_name_by_default.php
+++ b/database/migrations/2025_03_18_101811_disable_bank_reservation_name_by_default.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->boolean('bank_reservation_first_name')->default(false)->after('bank_reservation_number')->change();
+            $table->boolean('bank_reservation_last_name')->default(false)->after('bank_reservation_first_name')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->boolean('bank_reservation_first_name')->default(true)->after('bank_reservation_number')->change();
+            $table->boolean('bank_reservation_last_name')->default(true)->after('bank_reservation_first_name')->change();
+        });
+    }
+};


### PR DESCRIPTION
## Changes description

## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
