### PR TITLE
fix dusk tests for url stored filters

### DIFF
--- a/tests/Browser/Traits/HasFrontendActions.php
+++ b/tests/Browser/Traits/HasFrontendActions.php
@@ -302,7 +302,7 @@ trait HasFrontendActions
         int $expected = 1,
     ): void {
         $browser->waitFor($selector . 'Search');
-        $browser->typeSlowly($selector . 'Search', $value, .1);
+        $browser->typeSlowly($selector . 'Search', $value, 50);
 
         if ($id !== null) {
             $browser->waitFor($selector . "Row$id");


### PR DESCRIPTION
## Changes description

## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
