### PR TITLE
disable extra payment reservations from subsidy products

### DIFF
--- a/app/Models/Voucher.php
+++ b/app/Models/Voucher.php
@@ -1173,16 +1173,18 @@ class Voucher extends BaseModel
                 $amount = ($user_price > $this->amount_available) ?
                     ($product->price - ($user_price - $this->amount_available)) :
                     $product->price;
+                $extra_amount = $product->price - $amount;
+                $user_price = ($user_price - $extra_amount);
             } else {
                 $amount = ($product->price > $this->amount_available) ? $this->amount_available : $product->price;
+                $extra_amount = $product->price - $amount;
             }
 
             $state = ProductReservation::STATE_WAITING;
-            $extraAmount = $product->price - $amount;
         } else {
             $amount = $product->price;
             $state = ProductReservation::STATE_PENDING;
-            $extraAmount = 0;
+            $extra_amount = 0;
         }
 
         /** @var ProductReservation $reservation */
@@ -1194,7 +1196,7 @@ class Voucher extends BaseModel
             'product_id' => $product->id,
             'employee_id' => $employee?->id,
             'fund_provider_product_id' => $fundProviderProduct?->id,
-            'amount_extra' => $extraAmount,
+            'amount_extra' => $extra_amount,
             ...array_only($extraData, [
                 'first_name', 'last_name', 'user_note', 'note', 'phone', 'birth_date',
                 'street', 'house_nr', 'house_nr_addition', 'city', 'postal_code',

--- a/app/Models/Voucher.php
+++ b/app/Models/Voucher.php
@@ -45,7 +45,6 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Maatwebsite\Excel\Excel as ExcelModel;
 use Maatwebsite\Excel\Facades\Excel;
-use Matrix\Exception;
 use Throwable;
 use ZipArchive;
 
@@ -1171,10 +1170,13 @@ class Voucher extends BaseModel
 
         if ($hasExtraPayment) {
             if ($fundProviderProduct?->isPaymentTypeSubsidy()) {
-                throw new Exception('Extra payment types are not allowed');
+                $amount = ($user_price > $this->amount_available) ?
+                    ($product->price - ($user_price - $this->amount_available)) :
+                    $product->price;
+            } else {
+                $amount = ($product->price > $this->amount_available) ? $this->amount_available : $product->price;
             }
 
-            $amount = ($product->price > $this->amount_available) ? $this->amount_available : $product->price;
             $state = ProductReservation::STATE_WAITING;
             $extraAmount = $product->price - $amount;
         } else {

--- a/app/Rules/ProductReservations/ProductIdToReservationRule.php
+++ b/app/Rules/ProductReservations/ProductIdToReservationRule.php
@@ -50,6 +50,9 @@ class ProductIdToReservationRule extends BaseRule
             'voucher_id' => $voucher->id ?? null,
         ], Product::whereId($value))->first();
 
+        $providerProduct = $product->getFundProviderProduct($voucher->fund);
+        $userPrice = $product->fundPrice($voucher->fund);
+
         if (!$this->voucherId || !$voucher) {
             return $this->rejectTrans('voucher_address_required');
         }
@@ -71,8 +74,8 @@ class ProductIdToReservationRule extends BaseRule
         }
 
         if (
-            $product->fundPrice($voucher->fund) > $voucher->amount_available &&
-            !$this->isExtraPaymentEnabled($voucher, $product)
+            $userPrice > $voucher->amount_available &&
+            (!$this->isExtraPaymentEnabled($voucher, $product) || $providerProduct?->isPaymentTypeSubsidy())
         ) {
             return $this->rejectTrans('not_enough_voucher_funds');
         }

--- a/app/Rules/ProductReservations/ProductIdToReservationRule.php
+++ b/app/Rules/ProductReservations/ProductIdToReservationRule.php
@@ -50,9 +50,6 @@ class ProductIdToReservationRule extends BaseRule
             'voucher_id' => $voucher->id ?? null,
         ], Product::whereId($value))->first();
 
-        $providerProduct = $product->getFundProviderProduct($voucher->fund);
-        $userPrice = $product->fundPrice($voucher->fund);
-
         if (!$this->voucherId || !$voucher) {
             return $this->rejectTrans('voucher_address_required');
         }
@@ -74,8 +71,8 @@ class ProductIdToReservationRule extends BaseRule
         }
 
         if (
-            $userPrice > $voucher->amount_available &&
-            (!$this->isExtraPaymentEnabled($voucher, $product) || $providerProduct?->isPaymentTypeSubsidy())
+            $product->fundPrice($voucher->fund) > $voucher->amount_available &&
+            !$this->isExtraPaymentEnabled($voucher, $product)
         ) {
             return $this->rejectTrans('not_enough_voucher_funds');
         }


### PR DESCRIPTION
## Changes description


## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
