### PR TITLE
Update RolePermissionsTableSeeder for sponsor to be able to check reservations

### DIFF
--- a/database/seeders/RolePermissionsTableSeeder.php
+++ b/database/seeders/RolePermissionsTableSeeder.php
@@ -22,12 +22,12 @@ class RolePermissionsTableSeeder extends Seeder
             'manage_reimbursements', 'manage_implementation_notifications',
             'view_funds', 'view_person_bsn_data', 'manage_fund_texts', 'manage_validators', 'make_direct_payments',
             'manage_bi_connection', 'manage_payment_methods', 'view_funds_extra_payments', 'manage_payouts',
-            'view_identities', 'manage_identities',
+            'view_identities', 'manage_identities','view_vouchers',
         ],
         'finance' => [
             'view_finances', 'manage_vouchers', 'manage_reimbursements', 'manage_organization',
             'manage_funds', 'manage_transaction_bulks', 'make_direct_payments', 'manage_bank_connections',
-            'manage_payment_methods', 'view_funds_extra_payments', 'view_implementations',
+            'manage_payment_methods', 'view_funds_extra_payments', 'view_implementations','view_vouchers',
         ],
         'validation' => [
             'validate_records', 'view_funds', 'view_person_bsn_data',
@@ -44,7 +44,7 @@ class RolePermissionsTableSeeder extends Seeder
         ],
         'voucher_officer' => [
             'manage_funds', 'manage_vouchers', 'view_person_bsn_data', 'make_direct_payments', 'manage_reimbursements', 'manage_employees', 'view_finances',
-            'view_implementations',
+            'view_implementations','view_vouchers',
         ],
         'implementation_communication_manager' => [
             'view_funds', 'manage_implementation_cms', 'manage_implementation_notifications', 'manage_fund_texts',


### PR DESCRIPTION
## Changes description
Added `view_vouchers` permissions to the relevant roles in the seeder to be able to check reservations on voucher details: 
- Issue: https://github.com/teamforus/DevOps/issues/1331
- PR: https://github.com/teamforus/forus-backend/pull/2594


## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
