### PR TITLE
fix fund application when digid is optional

### DIFF
--- a/app/Policies/FundPolicy.php
+++ b/app/Policies/FundPolicy.php
@@ -244,7 +244,7 @@ class FundPolicy
      */
     public function check(Identity $identity, Fund $fund): Response|bool
     {
-        if ($fund->identityRequireBsnConfirmation($identity)) {
+        if ($fund->getImplementation()?->digid_required && $fund->identityRequireBsnConfirmation($identity)) {
             return $this->deny('BSN session expired, please sign-in again.');
         }
 


### PR DESCRIPTION
## Changes description

## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
