### PR TITLE
Hide reservation address controls if allow_profile is false

### DIFF
--- a/tests/Browser/FundRequestDigidWarningTest.php
+++ b/tests/Browser/FundRequestDigidWarningTest.php
@@ -8,8 +8,8 @@ use App\Models\Organization;
 use App\Services\DigIdService\Models\DigIdSession;
 use Illuminate\Foundation\Testing\WithFaker;
 use Laravel\Dusk\Browser;
-use Tests\Browser\Traits\HasFundRequestFormActions;
 use Tests\Browser\Traits\HasFrontendActions;
+use Tests\Browser\Traits\HasFundRequestFormActions;
 use Tests\DuskTestCase;
 use Tests\Traits\MakesTestFunds;
 use Tests\Traits\MakesTestOrganizations;
@@ -98,15 +98,8 @@ class FundRequestDigidWarningTest extends DuskTestCase
     {
         $requester = $this->makeIdentity($this->makeUniqueEmail());
 
-        // set a BSN for the requester to enable fund request option
-        $requester->setBsnRecord('12345678');
-
-        $this->browse(function (Browser $browser) use (
-            $implementation,
-            $fund,
-            $requester
-        ) {
-            $this->openFundRequestFormByDigiD($browser, $implementation, $fund, $requester);
+        $this->browse(function (Browser $browser) use ($implementation, $fund, $requester) {
+            $this->openFundRequestFormByDigiD($browser, $implementation, $fund, $requester, bsn: '12345678');
 
             // verify the warning and expiration messages is not shown ahead of time
             $browser->assertMissing('@bsnWarning');

--- a/tests/Browser/ProductReservationTest.php
+++ b/tests/Browser/ProductReservationTest.php
@@ -8,9 +8,9 @@ use App\Models\FundProvider;
 use App\Models\Identity;
 use App\Models\Implementation;
 use App\Models\Organization;
-use App\Models\ReservationField;
 use App\Models\Product;
 use App\Models\ProductReservation;
+use App\Models\ReservationField;
 use App\Models\Voucher;
 use App\Scopes\Builders\FundProviderQuery;
 use App\Services\MailDatabaseLoggerService\Traits\AssertsSentEmails;
@@ -536,15 +536,17 @@ class ProductReservationTest extends DuskTestCase
     public function testProductReservationRequiredAddress(): void
     {
         $organization = Implementation::byKey('nijmegen')->organization;
-        $allowProfiles = $organization->allow_profiles;
+        $fund = null;
 
-        $organization->forceFill([
-            'allow_profiles' => true,
-        ])->save();
+        $this->rollbackModels([
+            [$organization, $organization->only(['allow_profiles'])],
+        ], function () use ($organization, &$fund) {
+            $organization->forceFill([
+                'allow_profiles' => true,
+            ])->save();
 
-        $fund = $this->makeTestFund($organization);
+            $fund = $this->makeTestFund($organization);
 
-        try {
             $provider = $this->makeTestProviderOrganization($this->makeIdentity());
             $product = $this->makeTestProductForReservation($provider);
             $identity = $this->makeIdentity($this->makeUniqueEmail());
@@ -605,13 +607,9 @@ class ProductReservationTest extends DuskTestCase
                 'first_name' => $this->faker->firstName(),
                 'last_name' => $this->faker->lastName(),
             ], [...$addressData, 'existing' => true, 'optional' => true, 'skip' => true]);
-        } finally {
-            $fund->archive($fund->organization->employees[0]);
-
-            $organization->forceFill([
-                'allow_profiles' => $allowProfiles,
-            ])->save();
-        }
+        }, function () use (&$fund) {
+            $fund?->archive($fund->organization->employees[0]);
+        });
     }
 
     /**
@@ -621,15 +619,17 @@ class ProductReservationTest extends DuskTestCase
     public function testProductReservationRequiredAddressWithoutProfile(): void
     {
         $organization = Implementation::byKey('nijmegen')->organization;
-        $allowProfiles = $organization->allow_profiles;
+        $fund = null;
 
-        $organization->forceFill([
-            'allow_profiles' => false,
-        ])->save();
+        $this->rollbackModels([
+            [$organization, $organization->only(['allow_profiles'])],
+        ], function () use ($organization, &$fund) {
+            $organization->forceFill([
+                'allow_profiles' => false,
+            ])->save();
 
-        $fund = $this->makeTestFund($organization);
+            $fund = $this->makeTestFund($organization);
 
-        try {
             $provider = $this->makeTestProviderOrganization($this->makeIdentity());
             $product = $this->makeTestProductForReservation($provider);
             $identity = $this->makeIdentity($this->makeUniqueEmail());
@@ -657,6 +657,29 @@ class ProductReservationTest extends DuskTestCase
                 'last_name' => $this->faker->lastName(),
             ], [...$addressData, 'existing' => false, 'optional' => true, 'hidden_controls' => true]);
 
+            $userData = [
+                'first_name' => $this->faker->firstName(),
+                'last_name' => $this->faker->lastName(),
+            ];
+
+            // Test clearing an optional address after entering it
+            $this->assertProductCanBeReservedByIdentity($fund, $product, $identity, $userData, [
+                ...$addressData,
+                'existing' => false,
+                'optional' => true,
+                'hidden_controls' => true,
+                'clear_after_apply' => true,
+            ]);
+
+            $reservation = $this->findProductReservation($identity, $product, $fund, $userData);
+
+            $this->assertNull($reservation->street);
+            $this->assertNull($reservation->house_nr);
+            $this->assertNull($reservation->house_nr_addition);
+            $this->assertNull($reservation->postal_code);
+            $this->assertNull($reservation->city);
+            $this->assertSame('', $reservation->address);
+
             $product->forceFill([
                 'reservation_address' => Product::RESERVATION_FIELD_REQUIRED,
                 'reservation_fields_enabled' => true,
@@ -667,13 +690,9 @@ class ProductReservationTest extends DuskTestCase
                 'first_name' => $this->faker->firstName(),
                 'last_name' => $this->faker->lastName(),
             ], [...$addressData, 'existing' => false, 'hidden_controls' => true]);
-        } finally {
-            $fund->archive($fund->organization->employees[0]);
-
-            $organization->forceFill([
-                'allow_profiles' => $allowProfiles,
-            ])->save();
-        }
+        }, function () use (&$fund) {
+            $fund?->archive($fund->organization->employees[0]);
+        });
     }
 
     /**
@@ -1418,25 +1437,27 @@ class ProductReservationTest extends DuskTestCase
             $optional = $data['optional'] ?? false;
             $existing = $data['existing'] ?? false;
             $hiddenControls = $data['hidden_controls'] ?? false;
+            $clearAfterApply = $data['clear_after_apply'] ?? false;
             $existingUpdate = $data['existing_update'] ?? false;
 
             $apply = fn () => $hiddenControls
                 ? $browser->click('@btnSubmit')
                 : $browser->click('@productReserveAddressFormApply');
 
-            if (!$existing && $optional) {
-                $browser->waitFor('@productReserveAddress');
-                $browser->assertMissing('@btnSkip');
-                $browser->press('@btnSubmit');
-
-                return;
-            }
-
             if (!$existing) {
                 $browser->waitFor('@productReserveAddressForm');
 
-                if (!$hiddenControls) {
+                if ($hiddenControls) {
+                    $browser->assertMissing('@productReserveAddressActions');
+                } else {
                     $browser->assertDisabled('@productReserveAddressFormApply');
+                }
+
+                if ($optional && !$clearAfterApply) {
+                    $browser->assertMissing('@btnSkip');
+                    $browser->press('@btnSubmit');
+
+                    return;
                 }
 
                 // Fill form with data and submit again
@@ -1466,6 +1487,21 @@ class ProductReservationTest extends DuskTestCase
                 $browser->waitFor('@productReserveAddressPreview');
 
                 $browser->assertSeeIn('@productReserveAddressPreviewText', $this->makeAddressString($data));
+
+                if ($clearAfterApply) {
+                    $browser->waitFor('@productReserveAddressPreviewEdit');
+                    $browser->click('@productReserveAddressPreviewEdit');
+                    $browser->waitFor('@productReserveAddressForm');
+
+                    $browser->clear('@productReserveFormStreet');
+                    $browser->clear('@productReserveFormHouseNumber');
+                    $browser->clear('@productReserveFormHouseNumberAddition');
+                    $browser->clear('@productReserveFormPostalCode');
+                    $browser->clear('@productReserveFormCity');
+                    $browser->press('@btnSubmit');
+
+                    return;
+                }
 
                 if (!$hiddenControls) {
                     $browser->waitFor('@productReserveAddressPreviewEdit');

--- a/tests/Browser/ProductReservationTest.php
+++ b/tests/Browser/ProductReservationTest.php
@@ -535,7 +535,14 @@ class ProductReservationTest extends DuskTestCase
      */
     public function testProductReservationRequiredAddress(): void
     {
-        $fund = $this->makeTestFund(Implementation::byKey('nijmegen')->organization);
+        $organization = Implementation::byKey('nijmegen')->organization;
+        $allowProfiles = $organization->allow_profiles;
+
+        $organization->forceFill([
+            'allow_profiles' => true,
+        ])->save();
+
+        $fund = $this->makeTestFund($organization);
 
         try {
             $provider = $this->makeTestProviderOrganization($this->makeIdentity());
@@ -600,6 +607,72 @@ class ProductReservationTest extends DuskTestCase
             ], [...$addressData, 'existing' => true, 'optional' => true, 'skip' => true]);
         } finally {
             $fund->archive($fund->organization->employees[0]);
+
+            $organization->forceFill([
+                'allow_profiles' => $allowProfiles,
+            ])->save();
+        }
+    }
+
+    /**
+     * @throws Throwable
+     * @return void
+     */
+    public function testProductReservationRequiredAddressWithoutProfile(): void
+    {
+        $organization = Implementation::byKey('nijmegen')->organization;
+        $allowProfiles = $organization->allow_profiles;
+
+        $organization->forceFill([
+            'allow_profiles' => false,
+        ])->save();
+
+        $fund = $this->makeTestFund($organization);
+
+        try {
+            $provider = $this->makeTestProviderOrganization($this->makeIdentity());
+            $product = $this->makeTestProductForReservation($provider);
+            $identity = $this->makeIdentity($this->makeUniqueEmail());
+
+            $product->forceFill([
+                'reservation_address' => Product::RESERVATION_FIELD_OPTIONAL,
+                'reservation_fields_enabled' => true,
+            ])->save();
+
+            $this->makeTestVoucher($fund, $identity);
+            $this->makeTestFundProvider($provider, $fund);
+            $this->assertFundHasApprovedProviders($fund);
+
+            $addressData = [
+                'city' => 'Kraigmouth',
+                'street' => 'Hodkiewicz Parks',
+                'house_nr' => '8',
+                'house_nr_addition' => 'A',
+                'postal_code' => '1234AB',
+            ];
+
+            // Test reservation without optional address when no address is saved
+            $this->assertProductCanBeReservedByIdentity($fund, $product, $identity, [
+                'first_name' => $this->faker->firstName(),
+                'last_name' => $this->faker->lastName(),
+            ], [...$addressData, 'existing' => false, 'optional' => true, 'hidden_controls' => true]);
+
+            $product->forceFill([
+                'reservation_address' => Product::RESERVATION_FIELD_REQUIRED,
+                'reservation_fields_enabled' => true,
+            ])->save();
+
+            // Test required reservation address without saved address
+            $this->assertProductCanBeReservedByIdentity($fund, $product, $identity, [
+                'first_name' => $this->faker->firstName(),
+                'last_name' => $this->faker->lastName(),
+            ], [...$addressData, 'existing' => false, 'hidden_controls' => true]);
+        } finally {
+            $fund->archive($fund->organization->employees[0]);
+
+            $organization->forceFill([
+                'allow_profiles' => $allowProfiles,
+            ])->save();
         }
     }
 
@@ -1344,7 +1417,12 @@ class ProductReservationTest extends DuskTestCase
             $skip = $data['skip'] ?? false;
             $optional = $data['optional'] ?? false;
             $existing = $data['existing'] ?? false;
+            $hiddenControls = $data['hidden_controls'] ?? false;
             $existingUpdate = $data['existing_update'] ?? false;
+
+            $apply = fn () => $hiddenControls
+                ? $browser->click('@btnSubmit')
+                : $browser->click('@productReserveAddressFormApply');
 
             if (!$existing && $optional) {
                 $browser->waitFor('@productReserveAddress');
@@ -1356,7 +1434,10 @@ class ProductReservationTest extends DuskTestCase
 
             if (!$existing) {
                 $browser->waitFor('@productReserveAddressForm');
-                $browser->assertDisabled('@productReserveAddressFormApply');
+
+                if (!$hiddenControls) {
+                    $browser->assertDisabled('@productReserveAddressFormApply');
+                }
 
                 // Fill form with data and submit again
                 $browser->type('@productReserveFormStreet', $data['street']);
@@ -1365,11 +1446,14 @@ class ProductReservationTest extends DuskTestCase
                 $browser->type('@productReserveFormPostalCode', '---');
                 $browser->type('@productReserveFormCity', $data['city']);
 
-                $browser->click('@productReserveAddressFormApply');
+                $apply();
+
                 $browser->waitFor('.form-error');
 
-                $browser->click('@productReserveAddressFormClear');
-                $browser->assertDisabled('@productReserveAddressFormApply');
+                if (!$hiddenControls) {
+                    $browser->click('@productReserveAddressFormClear');
+                    $browser->assertDisabled('@productReserveAddressFormApply');
+                }
 
                 $browser->type('@productReserveFormStreet', $data['street']);
                 $browser->type('@productReserveFormHouseNumber', $data['house_nr']);
@@ -1377,28 +1461,34 @@ class ProductReservationTest extends DuskTestCase
                 $browser->type('@productReserveFormPostalCode', $data['postal_code']);
                 $browser->type('@productReserveFormCity', $data['city']);
 
-                $browser->click('@productReserveAddressFormApply');
+                $apply();
+
                 $browser->waitFor('@productReserveAddressPreview');
 
                 $browser->assertSeeIn('@productReserveAddressPreviewText', $this->makeAddressString($data));
 
-                $browser->waitFor('@productReserveAddressPreviewEdit');
-                $browser->assertPresent('@productReserveAddressPreviewEdit');
-                $browser->click('@productReserveAddressPreviewEdit');
+                if (!$hiddenControls) {
+                    $browser->waitFor('@productReserveAddressPreviewEdit');
+                    $browser->assertPresent('@productReserveAddressPreviewEdit');
+                    $browser->click('@productReserveAddressPreviewEdit');
 
-                $browser->assertPresent('@productReserveAddressFormApply');
-                $browser->click('@productReserveAddressFormSave');
+                    $browser->assertPresent('@productReserveAddressFormApply');
+                    $browser->click('@productReserveAddressFormSave');
+                }
             } else {
                 $browser->waitFor('@productReserveAddressPreview');
                 $browser->assertSeeIn('@productReserveAddressPreviewText', $this->makeAddressString($data));
             }
 
-            $browser->waitFor('@productReserveAddressPreviewEdit');
-            $browser->click('@productReserveAddressPreviewEdit');
+            if (!$hiddenControls) {
+                $browser->waitFor('@productReserveAddressPreviewEdit');
+                $browser->click('@productReserveAddressPreviewEdit');
 
-            $browser->waitFor('@productReserveAddressForm');
-            $browser->waitUntilMissing('@productReserveAddressFormApply');
-            $browser->assertMissing('@productReserveAddressFormApply');
+                $browser->waitFor('@productReserveAddressForm');
+
+                $browser->waitUntilMissing('@productReserveAddressFormApply');
+                $browser->assertMissing('@productReserveAddressFormApply');
+            }
 
             if ($existingUpdate) {
                 $browser->waitFor('@productReserveFormStreet');
@@ -1419,7 +1509,7 @@ class ProductReservationTest extends DuskTestCase
                 $browser->click('@productReserveAddressFormSave');
 
                 $browser->waitForTextIn('@productReserveAddressPreviewText', $this->makeAddressString($data));
-            } else {
+            } elseif (!$hiddenControls) {
                 $browser->click('@productReserveAddressFormCancel');
             }
 

--- a/tests/Browser/ProductReservationTest.php
+++ b/tests/Browser/ProductReservationTest.php
@@ -676,7 +676,7 @@ class ProductReservationTest extends DuskTestCase
             $this->assertNull($reservation->street);
             $this->assertNull($reservation->house_nr);
             $this->assertNull($reservation->house_nr_addition);
-            $this->assertNull($reservation->postal_code);
+            $this->assertSame('', $reservation->postal_code);
             $this->assertNull($reservation->city);
             $this->assertSame('', $reservation->address);
 
@@ -1493,11 +1493,11 @@ class ProductReservationTest extends DuskTestCase
                     $browser->click('@productReserveAddressPreviewEdit');
                     $browser->waitFor('@productReserveAddressForm');
 
-                    $browser->clear('@productReserveFormStreet');
-                    $browser->clear('@productReserveFormHouseNumber');
-                    $browser->clear('@productReserveFormHouseNumberAddition');
-                    $browser->clear('@productReserveFormPostalCode');
-                    $browser->clear('@productReserveFormCity');
+                    $this->clearField($browser, '@productReserveFormStreet');
+                    $this->clearField($browser, '@productReserveFormHouseNumber');
+                    $this->clearField($browser, '@productReserveFormHouseNumberAddition');
+                    $this->clearField($browser, '@productReserveFormPostalCode');
+                    $this->clearField($browser, '@productReserveFormCity');
                     $browser->press('@btnSubmit');
 
                     return;

--- a/tests/Browser/Traits/HasFundRequestFormActions.php
+++ b/tests/Browser/Traits/HasFundRequestFormActions.php
@@ -19,6 +19,7 @@ trait HasFundRequestFormActions
      * @param Fund $fund
      * @param Identity $requester
      * @param bool $assertForm
+     * @param string|null $bsn
      * @throws NoSuchElementException
      * @throws TimeoutException
      * @throws ElementClickInterceptedException
@@ -30,6 +31,7 @@ trait HasFundRequestFormActions
         Fund $fund,
         Identity $requester,
         bool $assertForm = true,
+        ?string $bsn = null,
     ): void {
         $browser->visit($implementation->urlWebshop());
         $this->loginIdentity($browser, $requester);
@@ -38,6 +40,10 @@ trait HasFundRequestFormActions
         $browser->visit($implementation->urlWebshop("fondsen/$fund->id"));
         $browser->waitFor('@fundTitle');
         $browser->assertSeeIn('@fundTitle', $fund->name);
+
+        if ($bsn !== null) {
+            $requester->setBsnRecord($bsn);
+        }
 
         $browser->waitFor('@requestButton')->click('@requestButton');
         $browser->waitFor('@digidOption')->click('@digidOption');


### PR DESCRIPTION
## Changes description
<!--- Describe shortly changes here if:
       - your solution differs from issue desrciption
       - there are advices from development side for QA or other stakeholders
-->

## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
