### PR TITLE
Do not show providers in rejected group state if any fund provider is active or pending

### DIFF
--- a/app/Scopes/Builders/OrganizationQuery.php
+++ b/app/Scopes/Builders/OrganizationQuery.php
@@ -212,6 +212,35 @@ class OrganizationQuery
                     $query->whereIn('fund_id', $fundsBuilder->select('id'));
                 });
 
+                static::whereProviderNotRejected($builder, $fundsBuilder);
+            });
+
+            $builder->orWhere(function (Builder $builder) use ($sponsorOrganization) {
+                $builder->whereHas('fund_providers', function (Builder $query) use ($sponsorOrganization) {
+                    $fundsBuilder = clone FundQuery::whereNotActiveFilter($sponsorOrganization->funds());
+
+                    $query->whereIn('fund_id', $fundsBuilder->select('id'));
+                });
+
+                static::whereProviderNotRejected(
+                    $builder,
+                    clone FundQuery::whereActiveFilter($sponsorOrganization->funds())
+                );
+            });
+        });
+    }
+
+    /**
+     * @param Builder|Relation|Organization $builder
+     * @param Builder|Relation|Fund $fundsBuilder
+     * @return Builder|Relation|Organization
+     */
+    public static function whereProviderNotRejected(
+        Builder|Relation|Organization $builder,
+        Builder|Relation|Fund $fundsBuilder,
+    ): Builder|Relation|Organization {
+        return $builder->where(function (Builder $builder) use ($fundsBuilder) {
+            $builder->where(function (Builder $builder) use ($fundsBuilder) {
                 $builder->whereDoesntHave('fund_providers', function (Builder $query) use ($fundsBuilder) {
                     $query->where('state', FundProvider::STATE_UNSUBSCRIBED);
                     $query->whereIn('fund_id', $fundsBuilder->select('id'));
@@ -226,12 +255,6 @@ class OrganizationQuery
                     $query->where('state', FundProvider::STATE_PENDING);
                     $query->whereIn('fund_id', $fundsBuilder->select('id'));
                 });
-            });
-
-            $builder->orWhereHas('fund_providers', function (Builder $query) use ($sponsorOrganization) {
-                $fundsBuilder = clone FundQuery::whereNotActiveFilter($sponsorOrganization->funds());
-
-                $query->whereIn('fund_id', $fundsBuilder->select('id'));
             });
         });
     }

--- a/tests/Unit/Searches/Sponsor/ProviderOrganizationSearchTest.php
+++ b/tests/Unit/Searches/Sponsor/ProviderOrganizationSearchTest.php
@@ -3,12 +3,15 @@
 namespace Tests\Unit\Searches\Sponsor;
 
 use App\Models\Fund;
+use App\Models\FundProvider;
 use App\Models\Identity;
 use App\Models\Organization;
 use App\Models\ProductReservation;
+use App\Scopes\Builders\OrganizationQuery;
 use App\Searches\OrganizationSearch;
 use App\Traits\DoesTesting;
-use Illuminate\Support\Carbon;;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
 use Tests\Traits\MakesProductReservations;
 use Tests\Traits\MakesTestBusinessType;
 use Tests\Traits\MakesTestFundRequests;
@@ -173,6 +176,178 @@ class ProviderOrganizationSearchTest extends SearchTestCase
     }
 
     /**
+     * @return void
+     */
+    public function testFiltersByGroupStateActive(): void
+    {
+        $sponsor = $this->makeTestOrganization($this->makeIdentity());
+        $provider = $this->makeTestProviderOrganization($this->makeIdentity());
+
+        // prepare two funds for sponsor
+        $fund1 = $this->makeTestFund($sponsor);
+        $fund2 = $this->makeTestFund($sponsor);
+
+        // make two fund providers for provider and prepared funds
+        $this->makeTestFundProvider($provider, $fund1);
+        $this->makeTestFundProvider($provider, $fund2);
+
+        $baseQuery = OrganizationQuery::whereIsProviderOrganization(Organization::query(), $sponsor);
+
+        // assert provider only available by active state when all fund providers are active and all funds are active
+        $this->assertIdsByGroupStates($sponsor, $baseQuery, activeIds: [$provider->id]);
+
+        $this->closeFund($fund1);
+
+        // assert provider only available by active state when all fund providers are active
+        // and one fund is closed and another still active
+        $this->assertIdsByGroupStates($sponsor, $baseQuery, activeIds: [$provider->id]);
+
+        $this->closeFund($fund2);
+
+        // assert provider only available by rejected state when all fund providers are active and all funds are closed
+        $this->assertIdsByGroupStates($sponsor, $baseQuery, rejectedIds: [$provider->id]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFiltersByGroupStatePending(): void
+    {
+        $sponsor = $this->makeTestOrganization($this->makeIdentity());
+        $provider = $this->makeTestProviderOrganization($this->makeIdentity());
+
+        // prepare two funds for sponsor
+        $fund1 = $this->makeTestFund($sponsor);
+        $fund2 = $this->makeTestFund($sponsor);
+
+        // make two fund providers for provider and prepared funds
+        $fundProviderFund1 = $this->makeTestFundProvider($provider, $fund1);
+        $fundProviderFund2 = $this->makeTestFundProvider($provider, $fund2);
+
+        // set fund providers as pending
+        $fundProviderFund1->update(['state' => FundProvider::STATE_PENDING]);
+        $fundProviderFund2->update(['state' => FundProvider::STATE_PENDING]);
+
+        $baseQuery = OrganizationQuery::whereIsProviderOrganization(Organization::query(), $sponsor);
+
+        // assert provider only available by pending state when all fund providers are pending and all funds are active
+        $this->assertIdsByGroupStates($sponsor, $baseQuery, pendingIds: [$provider->id]);
+
+        $this->closeFund($fund1);
+
+        // assert provider only available by pending state when all fund providers are pending
+        // and one fund is closed and another still active
+        $this->assertIdsByGroupStates($sponsor, $baseQuery, pendingIds: [$provider->id]);
+
+        // set fund provider 1 as accepted (related fund is closed)
+        $fundProviderFund1->update(['state' => FundProvider::STATE_ACCEPTED]);
+
+        // assert provider only available by pending state when one fund provider are pending and related fund active
+        // and another fund provider is pending and related fund is closed
+        $this->assertIdsByGroupStates($sponsor, $baseQuery, pendingIds: [$provider->id]);
+
+        // set fund provider 1 as pending (related fund is closed) and fund provider 2 as accepted (related fund is active)
+        $fundProviderFund1->update(['state' => FundProvider::STATE_PENDING]);
+        $fundProviderFund2->update(['state' => FundProvider::STATE_ACCEPTED]);
+
+        // assert provider only available by active state when one fund provider are pending and related fund closed
+        // and another fund provider is active and related fund is active
+        $this->assertIdsByGroupStates($sponsor, $baseQuery, activeIds: [$provider->id]);
+
+        $this->closeFund($fund2);
+
+        // assert provider only available by rejected state when all funds are closed
+        $this->assertIdsByGroupStates($sponsor, $baseQuery, rejectedIds: [$provider->id]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFiltersByGroupStateUnsubscribed(): void
+    {
+        $sponsor = $this->makeTestOrganization($this->makeIdentity());
+        $provider = $this->makeTestProviderOrganization($this->makeIdentity());
+
+        // prepare two funds for sponsor
+        $fund1 = $this->makeTestFund($sponsor);
+        $fund2 = $this->makeTestFund($sponsor);
+
+        // make two fund providers for provider and prepared funds
+        $fundProviderFund1 = $this->makeTestFundProvider($provider, $fund1);
+        $fundProviderFund2 = $this->makeTestFundProvider($provider, $fund2);
+
+        // set fund providers as unsubscribed
+        $fundProviderFund1->update(['state' => FundProvider::STATE_UNSUBSCRIBED]);
+        $fundProviderFund2->update(['state' => FundProvider::STATE_UNSUBSCRIBED]);
+
+        $baseQuery = OrganizationQuery::whereIsProviderOrganization(Organization::query(), $sponsor);
+
+        // assert provider only available by unsubscribed state when all fund providers are unsubscribed and all funds are active
+        $this->assertIdsByGroupStates($sponsor, $baseQuery, unsubscribedIds: [$provider->id]);
+
+        $this->closeFund($fund1);
+
+        // assert provider only available by unsubscribed state when all fund providers are unsubscribed
+        // and one fund is closed and another still active
+        $this->assertIdsByGroupStates($sponsor, $baseQuery, unsubscribedIds: [$provider->id]);
+
+        // set fund provider 1 as accepted (related fund is closed)
+        $fundProviderFund1->update(['state' => FundProvider::STATE_ACCEPTED]);
+
+        // assert provider only available by unsubscribed state when one fund provider are unsubscribed and related fund active
+        // and another fund provider is unsubscribed and related fund is closed
+        $this->assertIdsByGroupStates($sponsor, $baseQuery, unsubscribedIds: [$provider->id]);
+
+        $this->closeFund($fund2);
+
+        // assert provider only available by rejected state when all funds are closed
+        $this->assertIdsByGroupStates($sponsor, $baseQuery, rejectedIds: [$provider->id]);
+    }
+
+    /**
+     * @param Fund $fund
+     * @return void
+     */
+    private function closeFund(Fund $fund): void
+    {
+        $fund->update(['state' => Fund::STATE_CLOSED]);
+    }
+
+    /**
+     * @param Organization $sponsor
+     * @param Builder $query
+     * @param array $activeIds
+     * @param array $pendingIds
+     * @param array $rejectedIds
+     * @param array $unsubscribedIds
+     * @return void
+     */
+    private function assertIdsByGroupStates(
+        Organization $sponsor,
+        Builder $query,
+        array $activeIds = [],
+        array $pendingIds = [],
+        array $rejectedIds = [],
+        array $unsubscribedIds = [],
+    ): void {
+        // query by active state
+        $activeQuery = OrganizationQuery::whereGroupState(clone $query, $sponsor, 'active');
+        $this->assertSameIds($activeQuery, $activeIds);
+
+        // query by pending state
+        $pendingQuery = OrganizationQuery::whereGroupState(clone $query, $sponsor, 'pending');
+        $this->assertSameIds($pendingQuery, $pendingIds);
+
+        // query by rejected state
+        $rejectedQuery = OrganizationQuery::whereGroupState(clone $query, $sponsor, 'rejected');
+        $this->assertSameIds($rejectedQuery, $rejectedIds);
+
+        // query by unsubscribed state
+        $unsubscribedQuery = OrganizationQuery::whereGroupState(clone $query, $sponsor, 'unsubscribed');
+        $this->assertSameIds($unsubscribedQuery, $unsubscribedIds);
+    }
+
+    /**
      * @param Fund $fund
      * @param Organization $provider
      * @param Identity $identity
@@ -204,9 +379,19 @@ class ProviderOrganizationSearchTest extends SearchTestCase
      */
     private function assertSearchIds(array $filters, array $expectedIds, Organization $sponsor): void
     {
-        $expected = collect($expectedIds)->sort()->values()->toArray();
         $search = $this->makeSearch($filters);
-        $actual = collect($search->searchProviderOrganizations($sponsor)->pluck('id')->toArray())->sort()->values()->toArray();
+        $this->assertSameIds($search->searchProviderOrganizations($sponsor), $expectedIds);
+    }
+
+    /**
+     * @param Builder $builder
+     * @param array $expectedIds
+     * @return void
+     */
+    private function assertSameIds(Builder $builder, array $expectedIds): void
+    {
+        $expected = collect($expectedIds)->sort()->values()->toArray();
+        $actual = collect($builder->pluck('id')->toArray())->sort()->values()->toArray();
 
         $this->assertSame($expected, $actual);
     }


### PR DESCRIPTION
## Changes description
<!--- Describe shortly changes here if:
       - your solution differs from issue desrciption
       - there are advices from development side for QA or other stakeholders
-->

## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
