### PR TITLE
Remove x-correlation-id from backoffice requests

### DIFF
--- a/app/Services/BackofficeApiService/BackofficeApi.php
+++ b/app/Services/BackofficeApiService/BackofficeApi.php
@@ -106,9 +106,7 @@ class BackofficeApi
     {
         $log = $this->makeLog(self::ACTION_STATUS);
 
-        $response = $this->request('GET', $this->getEndpoint(self::ACTION_STATUS), headers: [
-            'x-correlation-id' => $log->correlation_id,
-        ]);
+        $response = $this->request('GET', $this->getEndpoint(self::ACTION_STATUS));
 
         if ($response['success'] ?? false) {
             return tap($log)->update(array_merge(Arr::only($response, [
@@ -288,9 +286,7 @@ class BackofficeApi
             $response = $backofficeApi->request('POST', $endpoint, array_merge($body, [
                 'id' => $requestId,
                 'bsn' => $log->bsn,
-            ]), [
-                'x-correlation-id' => $log->correlation_id,
-            ]);
+            ]));
 
             if ($response['success'] ?? false) {
                 $log->update([
@@ -385,9 +381,7 @@ class BackofficeApi
         $response = $this->request('POST', $endpoint, array_merge($body, [
             'id' => $requestId,
             'bsn' => $bsn,
-        ]), [
-            'x-correlation-id' => $log->correlation_id,
-        ]);
+        ]));
 
         if ($response['success'] ?? false) {
             return tap($log)->update(array_merge(Arr::only($response, [


### PR DESCRIPTION
## Changes description
<!--- Describe shortly changes here if:
       - your solution differs from issue desrciption
       - there are advices from development side for QA or other stakeholders
-->

## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
