### PR TITLE
Add label colors to cms info block

### DIFF
--- a/app/Services/CmsService/ImplementationBlocks/Configs/InfoCmsBlockConfig.php
+++ b/app/Services/CmsService/ImplementationBlocks/Configs/InfoCmsBlockConfig.php
@@ -107,6 +107,20 @@ class InfoCmsBlockConfig extends CmsBlockConfig
             'max' => 30,
             'translatable' => true,
         ], [
+            'key' => 'label_background_color',
+            'name' => $this->itemFieldText(self::ITEM_TYPE_POST, 'label_background_color', 'name'),
+            'type' => self::TYPE_COLOR,
+            'placeholder' => $this->itemFieldText(self::ITEM_TYPE_POST, 'label_background_color', 'placeholder'),
+            'required' => false,
+            'translatable' => false,
+        ], [
+            'key' => 'label_text_color',
+            'name' => $this->itemFieldText(self::ITEM_TYPE_POST, 'label_text_color', 'name'),
+            'type' => self::TYPE_COLOR,
+            'placeholder' => $this->itemFieldText(self::ITEM_TYPE_POST, 'label_text_color', 'placeholder'),
+            'required' => false,
+            'translatable' => false,
+        ], [
             'key' => 'title',
             'name' => $this->itemFieldText(self::ITEM_TYPE_POST, 'title', 'name'),
             'type' => self::TYPE_TEXT,

--- a/resources/lang/nl/cms.php
+++ b/resources/lang/nl/cms.php
@@ -63,6 +63,14 @@ return [
                             'hint' => 'Max. 30 tekens',
                             'placeholder' => 'Label...',
                         ],
+                        'label_background_color' => [
+                            'name' => 'Achtergrondkleur van label',
+                            'placeholder' => '#ffffff',
+                        ],
+                        'label_text_color' => [
+                            'name' => 'Tekstkleur van label',
+                            'placeholder' => '#4E4D40',
+                        ],
                         'title' => [
                             'name' => 'Titel',
                             'hint' => 'Max. 100 tekens',

--- a/tests/Feature/Cms/Concerns/InteractsWithImplementationCmsBlocks.php
+++ b/tests/Feature/Cms/Concerns/InteractsWithImplementationCmsBlocks.php
@@ -50,6 +50,8 @@ trait InteractsWithImplementationCmsBlocks
                 'item_type_key' => InfoCmsBlockConfig::ITEM_TYPE_POST,
                 'values' => [
                     'label' => 'First label',
+                    'label_background_color' => '#315EFD',
+                    'label_text_color' => '#ffffff',
                     'title' => 'First post',
                     'description' => 'First description',
                     'button_enabled' => true,

--- a/tests/Feature/Cms/ImplementationPageCmsBlockValidationTest.php
+++ b/tests/Feature/Cms/ImplementationPageCmsBlockValidationTest.php
@@ -68,6 +68,8 @@ class ImplementationPageCmsBlockValidationTest extends ImplementationCmsTestCase
         $this->assertSame([
             'media',
             'label',
+            'label_background_color',
+            'label_text_color',
             'title',
             'description',
             'button_enabled',

--- a/tests/Unit/Cms/Configs/InfoCmsBlockConfigTest.php
+++ b/tests/Unit/Cms/Configs/InfoCmsBlockConfigTest.php
@@ -50,6 +50,8 @@ class InfoCmsBlockConfigTest extends CmsBlockTestCase
         $this->assertSame([
             'media',
             'label',
+            'label_background_color',
+            'label_text_color',
             'title',
             'description',
             'button_enabled',
@@ -59,6 +61,9 @@ class InfoCmsBlockConfigTest extends CmsBlockTestCase
             'button_target_blank',
         ], array_column($config->itemFields(InfoCmsBlockConfig::ITEM_TYPE_POST), 'key'));
 
+        $labelBackgroundColor = $config->itemField(InfoCmsBlockConfig::ITEM_TYPE_POST, 'label_background_color');
+        $labelTextColor = $config->itemField(InfoCmsBlockConfig::ITEM_TYPE_POST, 'label_text_color');
+
         $media = $config->itemField(InfoCmsBlockConfig::ITEM_TYPE_POST, 'media');
         $title = $config->itemField(InfoCmsBlockConfig::ITEM_TYPE_POST, 'title');
         $buttonText = $config->itemField(InfoCmsBlockConfig::ITEM_TYPE_POST, 'button_text');
@@ -67,6 +72,9 @@ class InfoCmsBlockConfigTest extends CmsBlockTestCase
         $this->assertSame(CmsBlockConfig::TYPE_MEDIA, $media['type']);
         $this->assertSame('implementation_block_media', $media['media_type']);
         $this->assertFalse($media['translatable']);
+
+        $this->assertSame(CmsBlockConfig::TYPE_COLOR, $labelBackgroundColor['type']);
+        $this->assertSame(CmsBlockConfig::TYPE_COLOR, $labelTextColor['type']);
 
         $this->assertSame(CmsBlockConfig::TYPE_TEXT, $title['type']);
         $this->assertTrue($title['required']);

--- a/tests/Unit/Cms/ImplementationCmsBlockServiceValuesTest.php
+++ b/tests/Unit/Cms/ImplementationCmsBlockServiceValuesTest.php
@@ -106,6 +106,8 @@ class ImplementationCmsBlockServiceValuesTest extends TestCase
         $this->assertSame([
             'media' => $media->uid,
             'label' => null,
+            'label_background_color' => null,
+            'label_text_color' => null,
             'title' => 'Translated post title',
             'description' => 'Translated post description',
             'button_enabled' => '1',


### PR DESCRIPTION
## Changes description
<!--- Describe shortly changes here if:
       - your solution differs from issue desrciption
       - there are advices from development side for QA or other stakeholders
-->

## Developers checklist
- [ ] **Autotests are passed locally**
- [ ] **Migration rollback works** - if there is migration, check rollback
- [ ] **Autotests are added**:
   - bugfix - unit/feature test for this scenario if possible
   - new small/medium feature - simple feature test for positive scenarios

## QA checklist
- [ ] **Translations are done**
- [ ] **Endpoint is fast on dump** - if there is new endpoint or changed query, endpoints that are using changed query - working fast on production dump, <2s 
